### PR TITLE
Implemented a formatter for MessagePack for performance reasons

### DIFF
--- a/H.Formatters.MessagePack/H.Formatters.MessagePack.csproj
+++ b/H.Formatters.MessagePack/H.Formatters.MessagePack.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<RootNamespace>H.Formatters</RootNamespace>
+	</PropertyGroup>
+
+	<PropertyGroup Label="NuGet">
+		<Version>12.0.3.8</Version>
+		<Description>
+			This package adds MessagePack (based on neuecc/MessagePack-CSharp)
+		</Description>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <None Include="..\assets\nuget_icon.png" Link="nuget_icon.png">
+	    <PackagePath></PackagePath>
+	    <Pack>true</Pack>
+	  </None>
+	  <None Include="..\README.md" Link="README.md">
+	    <PackagePath></PackagePath>
+	    <Pack>true</Pack>
+	  </None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="MessagePackAnalyzer" Version="2.3.85" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\src\libs\H.Formatters\H.Formatters.csproj" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <PackageReference Include="MessagePack">
+	    <Version>2.3.85</Version>
+	  </PackageReference>
+	</ItemGroup>
+
+</Project>

--- a/H.Formatters.MessagePack/MessagePackFormatter.cs
+++ b/H.Formatters.MessagePack/MessagePackFormatter.cs
@@ -1,0 +1,31 @@
+﻿using MessagePack;
+
+namespace H.Formatters
+{
+    /// <summary>
+    /// A formatter that uses <see cref="MessagePackSerializer"/> inside for serialization/deserialization
+    /// </summary>
+    public class MessagePackFormatter : FormatterBase
+    {
+        /// <summary>
+        /// Serializes using <see cref="MessagePackSerializer"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override byte[] SerializeInternal(object obj)
+        {
+            return MessagePackSerializer.Serialize(obj);
+        }
+
+        /// <summary>
+        /// Deserializes using <see cref="MessagePackSerializer"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public override T DeserializeInternal<T>(byte[] bytes)
+        {
+            return MessagePackSerializer.Deserialize<T>(bytes);
+        }
+    }
+}

--- a/H.Pipes.Apps.ConsoleApp.MessagePack/H.Pipes.Apps.ConsoleApp.MessagePack.csproj
+++ b/H.Pipes.Apps.ConsoleApp.MessagePack/H.Pipes.Apps.ConsoleApp.MessagePack.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="MessagePack" Version="2.3.85" />
+	  <PackageReference Include="MessagePackAnalyzer" Version="2.3.85" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\H.Formatters.MessagePack\H.Formatters.MessagePack.csproj" />
+	  <ProjectReference Include="..\src\libs\H.Pipes\H.Pipes.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/H.Pipes.Apps.ConsoleApp.MessagePack/MyClient.cs
+++ b/H.Pipes.Apps.ConsoleApp.MessagePack/MyClient.cs
@@ -1,0 +1,69 @@
+﻿// ReSharper disable AccessToDisposedClosure
+
+using H.Formatters;
+
+namespace H.Pipes.Apps.ConsoleApp.MessagePack;
+
+internal static class MyClient
+{
+    private static void OnExceptionOccurred(Exception exception)
+    {
+        Console.Error.WriteLine($"Exception: {exception}");
+    }
+
+    public static async Task RunAsync(string pipeName)
+    {
+        try
+        {
+            using var source = new CancellationTokenSource();
+
+            Console.WriteLine($"Running in CLIENT mode. PipeName: {pipeName}");
+            Console.WriteLine("Enter 'q' to exit");
+
+            await using var client = new PipeClient<MyMessage>(pipeName, formatter: new MessagePackFormatter());
+            client.MessageReceived += (o, args) => Console.WriteLine("MessageReceived: " + args.Message);
+            client.Disconnected += (o, args) => Console.WriteLine("Disconnected from server");
+            client.Connected += (o, args) => Console.WriteLine("Connected to server");
+            client.ExceptionOccurred += (o, args) => OnExceptionOccurred(args.Exception);
+
+            // Dispose is not required
+            var _ = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        var message = await Console.In.ReadLineAsync().ConfigureAwait(false);
+                        if (message == "q")
+                        {
+                            source.Cancel();
+                            break;
+                        }
+
+                        await client.WriteAsync(new MyMessage
+                        {
+                            Text = message,
+                        }, source.Token).ConfigureAwait(false);
+                    }
+                    catch (Exception exception)
+                    {
+                        OnExceptionOccurred(exception);
+                    }
+                }
+            }, source.Token);
+
+            Console.WriteLine("Client connecting...");
+
+            await client.ConnectAsync(source.Token).ConfigureAwait(false);
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, source.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            OnExceptionOccurred(exception);
+        }
+    }
+}

--- a/H.Pipes.Apps.ConsoleApp.MessagePack/MyMessage.cs
+++ b/H.Pipes.Apps.ConsoleApp.MessagePack/MyMessage.cs
@@ -1,0 +1,19 @@
+﻿using MessagePack;
+
+namespace H.Pipes.Apps.ConsoleApp.MessagePack;
+
+[MessagePackObject]
+[Serializable]
+public class MyMessage
+{
+    [Key(0)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Key(1)]
+    public string? Text { get; set; }
+
+    public override string ToString()
+    {
+        return $"\"{Text}\" (message ID = {Id})";
+    }
+}

--- a/H.Pipes.Apps.ConsoleApp.MessagePack/MyServer.cs
+++ b/H.Pipes.Apps.ConsoleApp.MessagePack/MyServer.cs
@@ -1,0 +1,87 @@
+﻿// ReSharper disable AccessToDisposedClosure
+
+using H.Formatters;
+
+namespace H.Pipes.Apps.ConsoleApp.MessagePack;
+
+internal static class MyServer
+{
+    private static void OnExceptionOccurred(Exception exception)
+    {
+        Console.Error.WriteLine($"Exception: {exception}");
+    }
+
+    public static async Task RunAsync(string pipeName)
+    {
+        try
+        {
+            using var source = new CancellationTokenSource();
+
+            Console.WriteLine($"Running in SERVER mode. PipeName: {pipeName}");
+            Console.WriteLine("Enter 'q' to exit");
+
+            await using var server = new PipeServer<MyMessage>(pipeName, formatter: new MessagePackFormatter());
+            server.ClientConnected += async (_, args) =>
+            {
+                Console.WriteLine($"Client {args.Connection.PipeName} is now connected!");
+
+                try
+                {
+                    await args.Connection.WriteAsync(new MyMessage
+                    {
+                        Text = "Welcome!"
+                    }, source.Token).ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    OnExceptionOccurred(exception);
+                }
+            };
+            server.ClientDisconnected += (_, args) => Console.WriteLine($"Client {args.Connection.PipeName} disconnected");
+            server.MessageReceived += (_, args) => Console.WriteLine($"Client {args.Connection.PipeName} says: {args.Message}");
+            server.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+
+            var _ = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        var message = await Console.In.ReadLineAsync().ConfigureAwait(false);
+                        if (message == "q")
+                        {
+                            source.Cancel();
+                            break;
+                        }
+
+                        Console.WriteLine($"Sent to {server.ConnectedClients.Count} clients");
+
+                        await server.WriteAsync(new MyMessage
+                        {
+                            Text = message,
+                        }, source.Token).ConfigureAwait(false);
+                    }
+                    catch (Exception exception)
+                    {
+                        OnExceptionOccurred(exception);
+                    }
+                }
+            }, source.Token);
+
+            Console.WriteLine("Server starting...");
+
+            await server.StartAsync(cancellationToken: source.Token).ConfigureAwait(false);
+
+            Console.WriteLine("Server is started!");
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, source.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            OnExceptionOccurred(exception);
+        }
+    }
+}

--- a/H.Pipes.Apps.ConsoleApp.MessagePack/Program.cs
+++ b/H.Pipes.Apps.ConsoleApp.MessagePack/Program.cs
@@ -1,0 +1,28 @@
+﻿using H.Pipes.Apps.ConsoleApp.MessagePack;
+
+const string DefaultPipeName = "named_pipe_test_server";
+
+string? mode;
+string pipeName = DefaultPipeName;
+        if (args.Any())
+        {
+            mode = args.ElementAt(0);
+            pipeName = args.ElementAtOrDefault(1) ?? DefaultPipeName;
+        }
+        else
+{
+    Console.WriteLine("Enter mode('server' or 'client'):");
+    mode = await Console.In.ReadLineAsync().ConfigureAwait(false);
+}
+
+switch (mode?.ToUpperInvariant())
+{
+    case "SERVER":
+        await MyServer.RunAsync(pipeName).ConfigureAwait(false);
+        break;
+
+    default:
+        await MyClient.RunAsync(pipeName).ConfigureAwait(false);
+        break;
+}
+

--- a/H.Pipes.sln
+++ b/H.Pipes.sln
@@ -47,6 +47,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "H.Formatters.System.Text.Js
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "H.Pipes.Apps.ConsoleApp.Polly", "src\samples\H.Pipes.Apps.ConsoleApp.Polly\H.Pipes.Apps.ConsoleApp.Polly.csproj", "{97649173-79F3-4F73-9781-A1BF02C068F1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "H.Formatters.MessagePack", "H.Formatters.MessagePack\H.Formatters.MessagePack.csproj", "{6DBC119F-C8D4-4C2F-AF16-A9E8DDA9E2FA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "H.Pipes.Apps.ConsoleApp.MessagePack", "H.Pipes.Apps.ConsoleApp.MessagePack\H.Pipes.Apps.ConsoleApp.MessagePack.csproj", "{66052B3B-7EDC-4AE5-B8C1-A16E38768C2E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +101,14 @@ Global
 		{97649173-79F3-4F73-9781-A1BF02C068F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97649173-79F3-4F73-9781-A1BF02C068F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97649173-79F3-4F73-9781-A1BF02C068F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DBC119F-C8D4-4C2F-AF16-A9E8DDA9E2FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DBC119F-C8D4-4C2F-AF16-A9E8DDA9E2FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DBC119F-C8D4-4C2F-AF16-A9E8DDA9E2FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DBC119F-C8D4-4C2F-AF16-A9E8DDA9E2FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66052B3B-7EDC-4AE5-B8C1-A16E38768C2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66052B3B-7EDC-4AE5-B8C1-A16E38768C2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66052B3B-7EDC-4AE5-B8C1-A16E38768C2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66052B3B-7EDC-4AE5-B8C1-A16E38768C2E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +125,8 @@ Global
 		{C59B2734-C1CA-4A37-AF84-D1E4A26AF62A} = {DFAEA034-20D3-46BD-A2FB-E09CB731C4D7}
 		{45B6CF87-D741-4848-A903-8703C931464D} = {DFAEA034-20D3-46BD-A2FB-E09CB731C4D7}
 		{97649173-79F3-4F73-9781-A1BF02C068F1} = {A30A9D7F-0824-48AD-96F9-2944421541AD}
+		{6DBC119F-C8D4-4C2F-AF16-A9E8DDA9E2FA} = {DFAEA034-20D3-46BD-A2FB-E09CB731C4D7}
+		{66052B3B-7EDC-4AE5-B8C1-A16E38768C2E} = {A30A9D7F-0824-48AD-96F9-2944421541AD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3A24ECAC-930F-4D6F-B45E-07B16DD51C4E}


### PR DESCRIPTION
I needed a binary formatted message for performance reasons. So, I used MessagePack to achieve this goal. Also, it is possible with MessagePack to convert to JSON for debugging purposes. In my project, I used a couple of `#IF DEBUG`s but it would be unnecessary for this context. The performance gain is not huge but it helps when the traffic load gets higher.

Currently, it only supports .NET Standard 2.0 and above. .NET Framework support does not exist.

**P.S:** Initially I was planning to use ZeroFormatter, but since the benchmarks show no significant gain and MessagePack has the ability to convert to JSON quickly, I took that path.

**P.S 2:** You created such a nicely crafted library that implementing such a thing was trivial. I appreciate your craftsmanship! Since I used this in my personal project, I believe it would be better to contribute to the project itself.