### PR TITLE
Non-generic pipes

### DIFF
--- a/src/libs/H.Formatters.Inferno/PipeClientExtensions.cs
+++ b/src/libs/H.Formatters.Inferno/PipeClientExtensions.cs
@@ -27,7 +27,7 @@ public static class PipeClientExtensions
         Action<Exception>? exceptionAction = null)
     {
         client = client ?? throw new ArgumentNullException(nameof(client));
-        client.Connected += async (_, connArgs) =>
+        client.Connected += static async (_, args) =>
         {
             try
             {

--- a/src/libs/H.Formatters.Inferno/PipeConnectionExtensions.cs
+++ b/src/libs/H.Formatters.Inferno/PipeConnectionExtensions.cs
@@ -10,12 +10,11 @@ public static class PipeConnectionExtensions
     /// <summary>
     /// Waits key exchange.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
     /// <param name="connection"></param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static async Task WaitExchangeAsync<T>(
-        this PipeConnection<T> connection,
+    public static async Task WaitExchangeAsync(
+        this IPipeConnection connection,
         CancellationToken cancellationToken = default)
     {
         connection = connection ?? throw new ArgumentNullException(nameof(connection));

--- a/src/libs/H.Formatters.Inferno/PipeServerExtensions.cs
+++ b/src/libs/H.Formatters.Inferno/PipeServerExtensions.cs
@@ -27,44 +27,44 @@ public static class PipeServerExtensions
         Action<Exception>? exceptionAction = null)
     {
         server = server ?? throw new ArgumentNullException(nameof(server));
-        server.ClientConnected += async (_, connArgs) =>
+        server.ClientConnected += async (_, args) =>
         {
             try
             {
                 using var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
                 var cancellationToken = source.Token;
 
-                var pipeName = $"{connArgs.Connection.PipeName}_Inferno";
-                var infServer = new SingleConnectionPipeServer(pipeName, connArgs.Connection.Formatter);
+                var pipeName = $"{args.Connection.PipeName}_Inferno";
+                var server = new SingleConnectionPipeServer(pipeName, args.Connection.Formatter);
 
-                infServer.ExceptionOccurred += (_, exArgs) =>
+                server.ExceptionOccurred += (_, args) =>
                 {
-                    Debug.WriteLine($"{nameof(EnableEncryption)} server returns exception: {exArgs.Exception}");
+                    Debug.WriteLine($"{nameof(EnableEncryption)} server returns exception: {args.Exception}");
 
-                    exceptionAction?.Invoke(exArgs.Exception);
+                    exceptionAction?.Invoke(args.Exception);
                 };
 
-                await using (infServer.ConfigureAwait(false))
+                await using (server.ConfigureAwait(false))
                 {
-                    await infServer.StartAsync(cancellationToken).ConfigureAwait(false);
+                    await server.StartAsync(cancellationToken).ConfigureAwait(false);
 
-                    var response = await infServer.WaitMessageAsync<byte[]>(cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var response = await server.WaitMessageAsync<byte[]>(cancellationToken: cancellationToken).ConfigureAwait(false);
                     var clientPublicKey = response.Message;
 
                     using var keyPair = new KeyPair();
 
-                    connArgs.Connection.Formatter = new InfernoFormatter(
-                        connArgs.Connection.Formatter,
+                    args.Connection.Formatter = new InfernoFormatter(
+                        args.Connection.Formatter,
                         keyPair.GenerateSharedKey(clientPublicKey));
 
-                    await infServer.WriteAsync(keyPair.PublicKey, cancellationToken).ConfigureAwait(false);
+                    await server.WriteAsync(keyPair.PublicKey, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception exception)
             {
                 Debug.WriteLine($"{nameof(EnableEncryption)} returns exception: {exception}");
 
-                await connArgs.Connection.StopAsync().ConfigureAwait(false);
+                await args.Connection.StopAsync().ConfigureAwait(false);
 
                 exceptionAction?.Invoke(exception);
             }

--- a/src/libs/H.Pipes.AccessControl/PipeServerExtensions.cs
+++ b/src/libs/H.Pipes.AccessControl/PipeServerExtensions.cs
@@ -11,7 +11,7 @@ public static class PipeServerExtensions
 {
     /// <summary>
     /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/> <br/>
-    /// Overrides <see cref="PipeServer{T}.CreatePipeStreamFunc"/>
+    /// Overrides <see cref="PipeServer.CreatePipeStreamFunc"/>
     /// </summary>
     /// <param name="server"></param>
     /// <param name="pipeSecurity"></param>

--- a/src/libs/H.Pipes/Args/ConnectionEventArgs.cs
+++ b/src/libs/H.Pipes/Args/ConnectionEventArgs.cs
@@ -3,19 +3,18 @@
 /// <summary>
 /// Handles new connections.
 /// </summary>
-/// <typeparam name="T">Reference type</typeparam>
-public class ConnectionEventArgs<T> : EventArgs
+public class ConnectionEventArgs : EventArgs
 {
     /// <summary>
     /// Connection
     /// </summary>
-    public PipeConnection<T> Connection { get; }
+    public PipeConnection Connection { get; }
 
     /// <summary>
     /// 
     /// </summary>
     /// <param name="connection"></param>
-    public ConnectionEventArgs(PipeConnection<T> connection)
+    public ConnectionEventArgs(PipeConnection connection)
     {
         Connection = connection ?? throw new ArgumentNullException(nameof(connection));
     }

--- a/src/libs/H.Pipes/Args/ConnectionExceptionEventArgs.cs
+++ b/src/libs/H.Pipes/Args/ConnectionExceptionEventArgs.cs
@@ -3,8 +3,7 @@
 /// <summary>
 /// Handles exceptions thrown during read/write operations.
 /// </summary>
-/// <typeparam name="T">Reference type</typeparam>
-public class ConnectionExceptionEventArgs<T> : ConnectionEventArgs<T>
+public class ConnectionExceptionEventArgs : ConnectionEventArgs
 {
     /// <summary>
     /// The exception that was thrown
@@ -16,7 +15,7 @@ public class ConnectionExceptionEventArgs<T> : ConnectionEventArgs<T>
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="exception"></param>
-    public ConnectionExceptionEventArgs(PipeConnection<T> connection, Exception exception) : base(connection)
+    public ConnectionExceptionEventArgs(PipeConnection connection, Exception exception) : base(connection)
     {
         Exception = exception ?? throw new ArgumentNullException(nameof(exception));
     }

--- a/src/libs/H.Pipes/Args/ConnectionMessageEventArgs.cs
+++ b/src/libs/H.Pipes/Args/ConnectionMessageEventArgs.cs
@@ -1,10 +1,14 @@
-﻿namespace H.Pipes.Args;
+﻿using H.Formatters;
+using H.Pipes.Extensions;
+
+namespace H.Pipes.Args;
+
 
 /// <summary>
 /// Handles messages received from a named pipe.
 /// </summary>
 /// <typeparam name="T">Reference type</typeparam>
-public class ConnectionMessageEventArgs<T> : ConnectionEventArgs<T>
+public class ConnectionMessageEventArgs<T> : ConnectionEventArgs
 {
     /// <summary>
     /// Message sent by the other end of the pipe
@@ -16,7 +20,7 @@ public class ConnectionMessageEventArgs<T> : ConnectionEventArgs<T>
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="message"></param>
-    public ConnectionMessageEventArgs(PipeConnection<T> connection, T message) : base(connection)
+    public ConnectionMessageEventArgs(PipeConnection connection, T message) : base(connection)
     {
         Message = message;
     }

--- a/src/libs/H.Pipes/Extensions/ConnectionExtensions.cs
+++ b/src/libs/H.Pipes/Extensions/ConnectionExtensions.cs
@@ -17,11 +17,11 @@ public static class ConnectionExtensions
     /// <param name="cancellationToken"></param>
     /// <exception cref="OperationCanceledException"></exception>
     /// <returns></returns>
-    public static async Task<ConnectionMessageEventArgs<T>> WaitMessageAsync<T>(this IPipeConnection<T> connection, Func<CancellationToken, Task>? func = null, CancellationToken cancellationToken = default)
+    public static async Task<ConnectionMessageEventArgs<T>> WaitMessageAsync<T>(this IPipe connection, Func<CancellationToken, Task>? func = null, CancellationToken cancellationToken = default)
     {
         return await connection.WaitEventAsync<ConnectionMessageEventArgs<T>>(
-            func ?? (token => Task.Delay(TimeSpan.Zero, cancellationToken)),
-            nameof(connection.MessageReceived),
+            func ?? (_ => Task.Delay(TimeSpan.Zero, cancellationToken)),
+            nameof(IPipe.MessageReceived),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -35,10 +35,10 @@ public static class ConnectionExtensions
     /// <param name="func"></param>
     /// <exception cref="OperationCanceledException"></exception>
     /// <returns></returns>
-    public static async Task<ConnectionMessageEventArgs<T>> WaitMessageAsync<T>(this IPipeConnection<T> connection, TimeSpan timeout, Func<CancellationToken, Task>? func = null)
+    public static async Task<ConnectionMessageEventArgs<T>> WaitMessageAsync<T>(this IPipe connection, TimeSpan timeout, Func<CancellationToken, Task>? func = null)
     {
         using var tokenSource = new CancellationTokenSource(timeout);
 
-        return await connection.WaitMessageAsync(func, tokenSource.Token).ConfigureAwait(false);
+        return await connection.WaitMessageAsync<T>(func, tokenSource.Token).ConfigureAwait(false);
     }
 }

--- a/src/libs/H.Pipes/Extensions/FormatterExtensions.cs
+++ b/src/libs/H.Pipes/Extensions/FormatterExtensions.cs
@@ -22,8 +22,8 @@ public static class FormatterExtensions
     /// </param>
     /// <returns>Serialized object.</returns>
     public static async Task<byte[]> SerializeAsync<T>(
-        this T            value,
-        IFormatter        formatter,
+        this IFormatter   formatter,
+        T                 value,
         CancellationToken cancellationToken)
     {
         if (formatter == null)
@@ -44,8 +44,8 @@ public static class FormatterExtensions
     /// </param>
     /// <returns>System.Nullable&lt;T&gt;.</returns>
     public static async Task<T?> DeserializeAsync<T>(
-        this byte[]       bytes,
-        IFormatter        formatter,
+        this IFormatter   formatter,
+        byte[]            bytes,
         CancellationToken cancellationToken)
     {
         if (formatter == null)

--- a/src/libs/H.Pipes/Extensions/FormatterExtensions.cs
+++ b/src/libs/H.Pipes/Extensions/FormatterExtensions.cs
@@ -1,0 +1,60 @@
+﻿using H.Formatters;
+
+namespace H.Pipes.Extensions;
+
+/// <summary>
+/// Class FormatterExtensions.
+/// </summary>
+public static class FormatterExtensions
+{
+    #region Methods
+
+    /// <summary>
+    ///     Uses the <paramref name="formatter" /> to serialize the given object into a byte
+    ///     array.
+    /// </summary>
+    /// <typeparam name="T">Object type</typeparam>
+    /// <param name="value">The object instance.</param>
+    /// <param name="formatter">The formatter</param>
+    /// <param name="cancellationToken">
+    ///     The cancellation token that can be used by other objects or
+    ///     threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>Serialized object.</returns>
+    public static async Task<byte[]> SerializeAsync<T>(
+        this T            value,
+        IFormatter        formatter,
+        CancellationToken cancellationToken)
+    {
+        if (formatter == null)
+            throw new ArgumentNullException(nameof(formatter));
+
+        return formatter is IAsyncFormatter asyncFormatter
+            ? await asyncFormatter.SerializeAsync(value, cancellationToken).ConfigureAwait(false)
+            : formatter.Serialize(value);
+    }
+
+    /// <summary>Deserializes the bytes into the specified type using <paramref name="formatter" />.</summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="bytes">The bytes.</param>
+    /// <param name="formatter">The formatter.</param>
+    /// <param name="cancellationToken">
+    ///     The cancellation token that can be used by other objects or
+    ///     threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>System.Nullable&lt;T&gt;.</returns>
+    public static async Task<T?> DeserializeAsync<T>(
+        this byte[]       bytes,
+        IFormatter        formatter,
+        CancellationToken cancellationToken)
+    {
+        if (formatter == null)
+            throw new ArgumentNullException(nameof(formatter));
+
+        return formatter is IAsyncFormatter asyncFormatter
+            ? await asyncFormatter.DeserializeAsync<T>(bytes, cancellationToken).ConfigureAwait(false)
+            : formatter.Deserialize<T>(bytes);
+    }
+
+    #endregion
+}

--- a/src/libs/H.Pipes/IPipe.cs
+++ b/src/libs/H.Pipes/IPipe.cs
@@ -1,0 +1,53 @@
+﻿using H.Formatters;
+using H.Pipes.Args;
+
+namespace H.Pipes;
+
+/// <summary>
+/// Base class of all connections
+/// </summary>
+public interface IPipe : IAsyncDisposable
+{
+    #region Properties
+
+    /// <summary>
+    /// Used formatter
+    /// </summary>
+    public IFormatter Formatter { get; }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a message is received.
+    /// </summary>
+    event EventHandler<ConnectionMessageEventArgs<byte[]?>>? MessageReceived;
+
+    /// <summary>
+    /// Invoked whenever an exception is thrown during a read or write operation on the named pipe.
+    /// </summary>
+    event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Sends a message over a named pipe. <br/>
+    /// </summary>
+    /// <param name="value">Message to send</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    Task WriteAsync(byte[] value, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a message to all connected clients asynchronously.
+    /// This method returns immediately, possibly before the message has been sent to all clients.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="cancellationToken"></param>
+    Task WriteAsync<T>(T value, CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/libs/H.Pipes/IPipeClient.cs
+++ b/src/libs/H.Pipes/IPipeClient.cs
@@ -4,10 +4,40 @@ using H.Pipes.Args;
 namespace H.Pipes;
 
 /// <summary>
-/// Wraps a <see cref="NamedPipeClientStream"/>.
+/// Specialized version of <see cref="IPipeClient"/> for communications based
+/// on a single type
 /// </summary>
 /// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public interface IPipeClient<T> : IPipeConnection<T>
+/// <seealso cref="H.Pipes.IPipeClient" />
+public interface IPipeClient<T> : IPipeClient
+{
+
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a message is received.
+    /// </summary>
+    new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Sends a message over a named pipe. <br/>
+    /// </summary>
+    /// <param name="value">Message to send</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    Task WriteAsync(T value, CancellationToken cancellationToken = default);
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeClientStream"/>.
+/// </summary>
+public interface IPipeClient : IPipe
 {
     #region Properties
 
@@ -46,7 +76,7 @@ public interface IPipeClient<T> : IPipeConnection<T>
     /// <summary>
     /// Active connection.
     /// </summary>
-    public PipeConnection<T>? Connection { get; }
+    public PipeConnection? Connection { get; }
 
     #endregion
 
@@ -55,12 +85,12 @@ public interface IPipeClient<T> : IPipeConnection<T>
     /// <summary>
     /// Invoked after each the client connect to the server (include reconnects).
     /// </summary>
-    event EventHandler<ConnectionEventArgs<T>>? Connected;
+    event EventHandler<ConnectionEventArgs>? Connected;
 
     /// <summary>
     /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
     /// </summary>
-    event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+    event EventHandler<ConnectionEventArgs>? Disconnected;
 
     #endregion
 

--- a/src/libs/H.Pipes/IPipeConnection.cs
+++ b/src/libs/H.Pipes/IPipeConnection.cs
@@ -1,46 +1,89 @@
-﻿using H.Formatters;
+﻿using System.IO.Pipes;
+using H.Formatters;
 using H.Pipes.Args;
 
 namespace H.Pipes;
 
 /// <summary>
-/// Base class of all connections
+/// Represents a connection between a named pipe client and server.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public interface IPipeConnection<T> : IAsyncDisposable
+public interface IPipeConnection
 {
     #region Properties
 
+    /// <summary>Used formatter</summary>
+    IFormatter Formatter { get; set; }
+
+    /// <summary>Gets a value indicating whether the pipe is connected or not.</summary>
+    bool IsConnected { get; }
+
+    /// <summary><see langword="true" /> if started and not disposed.</summary>
+    bool IsStarted { get; }
+
+    /// <summary>Gets the connection's pipe name.</summary>
+    string PipeName { get; }
+
     /// <summary>
-    /// Used formatter
+    ///     Raw pipe stream. You can cast it to <see cref="NamedPipeClientStream" /> or
+    ///     <see cref="NamedPipeServerStream" />.
     /// </summary>
-    public IFormatter Formatter { get; }
+    PipeStream PipeStream { get; }
+
+    /// <summary>Gets the connection's server name. Only for client connections.</summary>
+    string ServerName { get; }
 
     #endregion
 
     #region Events
 
-    /// <summary>
-    /// Invoked whenever a message is received.
-    /// </summary>
-    event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    /// <summary>Invoked when the named pipe connection terminates.</summary>
+    event EventHandler<ConnectionEventArgs>? Disconnected;
+
+    /// <summary>Invoked whenever a message is received from the other end of the pipe.</summary>
+    event EventHandler<ConnectionExceptionEventArgs>? ExceptionOccurred;
 
     /// <summary>
-    /// Invoked whenever an exception is thrown during a read or write operation on the named pipe.
+    ///     Invoked when an exception is thrown during any read/write operation over the named
+    ///     pipe.
     /// </summary>
-    event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
+    event EventHandler<ConnectionMessageEventArgs<byte[]?>>? MessageReceived;
 
     #endregion
 
     #region Methods
 
     /// <summary>
-    /// Sends a message over a named pipe. <br/>
+    ///     Begins reading from and writing to the named pipe on a background thread. This method
+    ///     returns immediately.
     /// </summary>
-    /// <param name="value">Message to send</param>
+    void Start();
+
+    /// <summary>Dispose internal resources</summary>
+    Task StopAsync();
+
+    /// <summary>Writes the specified <paramref name="value" /> and waits other end reading</summary>
+    /// <param name="value"></param>
     /// <param name="cancellationToken"></param>
-    /// <exception cref="InvalidOperationException"></exception>
-    Task WriteAsync(T value, CancellationToken cancellationToken = default);
+    Task WriteAsync(byte[] value, CancellationToken cancellationToken = default);
+
+    /// <summary>Writes the specified <paramref name="value" /> and waits other end reading</summary>
+    /// <param name="value"></param>
+    /// <param name="cancellationToken"></param>
+    Task WriteAsync<T>(T value, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the user name of the client on the other end of the pipe.</summary>
+    /// <returns>The user name of the client on the other end of the pipe.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     <see cref="PipeStream" /> is not
+    ///     <see cref="NamedPipeServerStream" />.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">No pipe connections have been made yet.</exception>
+    /// <exception cref="InvalidOperationException">The connected pipe has already disconnected.</exception>
+    /// <exception cref="InvalidOperationException">The pipe handle has not been set.</exception>
+    /// <exception cref="ObjectDisposedException">The pipe is closed.</exception>
+    /// <exception cref="IOException">The pipe connection has been broken.</exception>
+    /// <exception cref="IOException">The user name of the client is longer than 19 characters.</exception>
+    string GetImpersonationUserName();
 
     #endregion
 }

--- a/src/libs/H.Pipes/IPipeServer.cs
+++ b/src/libs/H.Pipes/IPipeServer.cs
@@ -4,10 +4,40 @@ using H.Pipes.Args;
 namespace H.Pipes;
 
 /// <summary>
-/// 
+/// Specialized version of <see cref="IPipeServer"/> for communications based
+/// on a single type
 /// </summary>
 /// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public interface IPipeServer<T> : IPipeConnection<T>
+/// <seealso cref="H.Pipes.IPipeServer" />
+public interface IPipeServer<T> : IPipeServer
+{
+
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a message is received.
+    /// </summary>
+    new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Sends a message over a named pipe. <br/>
+    /// </summary>
+    /// <param name="value">Message to send</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    Task WriteAsync(T value, CancellationToken cancellationToken = default);
+
+    #endregion
+}
+
+/// <summary>
+/// 
+/// </summary>
+public interface IPipeServer : IPipe
 {
     #region Properties
 
@@ -38,12 +68,12 @@ public interface IPipeServer<T> : IPipeConnection<T>
     /// <summary>
     /// Invoked whenever a client connects to the server.
     /// </summary>
-    event EventHandler<ConnectionEventArgs<T>>? ClientConnected;
+    event EventHandler<ConnectionEventArgs>? ClientConnected;
 
     /// <summary>
     /// Invoked whenever a client disconnects from the server.
     /// </summary>
-    event EventHandler<ConnectionEventArgs<T>>? ClientDisconnected;
+    event EventHandler<ConnectionEventArgs>? ClientDisconnected;
 
     #endregion
 
@@ -61,6 +91,38 @@ public interface IPipeServer<T> : IPipeConnection<T>
     /// Closes all open client connections and stops listening for new ones.
     /// </summary>
     Task StopAsync(CancellationToken _ = default);
+
+    /// <summary>
+    /// Sends a message to all connected clients asynchronously.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="predicate"></param>
+    /// <param name="cancellationToken"></param>
+    Task WriteAsync(byte[] value, Predicate<IPipeConnection>? predicate, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a message to the given client by pipe name.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="pipeName"></param>
+    /// <param name="cancellationToken"></param>
+    Task WriteAsync(byte[] value, string pipeName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a message to all connected clients asynchronously.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="predicate"></param>
+    /// <param name="cancellationToken"></param>
+    Task WriteAsync<T>(T value, Predicate<IPipeConnection>? predicate, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a message to the given client by pipe name.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="pipeName"></param>
+    /// <param name="cancellationToken"></param>
+    Task WriteAsync<T>(T value, string pipeName, CancellationToken cancellationToken = default);
 
     #endregion
 }

--- a/src/libs/H.Pipes/PipeClient.cs
+++ b/src/libs/H.Pipes/PipeClient.cs
@@ -8,9 +8,73 @@ namespace H.Pipes;
 
 /// <summary>
 /// Wraps a <see cref="NamedPipeClientStream"/>.
+/// Specialized version of <see cref="PipeClient"/> for communications based on a single type.
+/// Implements the <see cref="H.Pipes.PipeClient" />
+/// Implements the <see cref="H.Pipes.IPipeClient{T}" />
 /// </summary>
 /// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class PipeClient<T> : IPipeClient<T>
+/// <seealso cref="H.Pipes.PipeClient" />
+/// <seealso cref="H.Pipes.IPipeClient{T}" />
+public class PipeClient<T> : PipeClient, IPipeClient<T>
+{
+    #region Constructors
+    
+    /// <inheritdoc />
+    public PipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default, IFormatter? formatter = default) : base(pipeName, serverName, reconnectionInterval, formatter) { }
+
+    #endregion
+
+    #region Events
+
+    /// <inheritdoc />
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <summary>
+    /// Calls the <see cref="MessageReceived"/> event.
+    /// </summary>
+    /// <param name="args">The arguments.</param>
+    protected void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    {
+        MessageReceived?.Invoke(this, args);
+    }
+
+    #endregion
+
+    #region Public methods
+
+    /// <inheritdoc />
+    public Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    {
+        return base.WriteAsync(value, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    protected override PipeConnection SetupPipeConnection(
+        PipeStream dataPipe, string connectionPipeName, IFormatter formatter, string serverName)
+    {
+        var connection = new PipeConnection<T>(dataPipe, connectionPipeName, formatter, serverName);
+
+        connection.Disconnected += async (_, args) =>
+        {
+            await DisconnectInternalAsync().ConfigureAwait(false);
+
+            OnDisconnected(args);
+        };
+        connection.MessageReceived   += (_, args) => OnMessageReceived(args);
+        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+
+        return connection;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeClientStream"/>.
+/// Implements the <see cref="H.Pipes.IPipeClient" />
+/// </summary>
+/// <seealso cref="H.Pipes.IPipeClient" />
+public class PipeClient : IPipeClient
 {
     #region Fields
 
@@ -33,7 +97,7 @@ public sealed class PipeClient<T> : IPipeClient<T>
     public bool IsConnecting
     {
         get => _isConnecting;
-        private set => _isConnecting = value;
+        protected set => _isConnecting = value;
     }
 
     /// <inheritdoc/>
@@ -46,9 +110,13 @@ public sealed class PipeClient<T> : IPipeClient<T>
     public string ServerName { get; }
 
     /// <inheritdoc/>
-    public PipeConnection<T>? Connection { get; private set; }
+    public PipeConnection? Connection { get; protected set; }
 
-    private System.Timers.Timer ReconnectionTimer { get; }
+    /// <summary>
+    /// Gets the reconnection timer.
+    /// </summary>
+    /// <value>The reconnection timer.</value>
+    protected System.Timers.Timer ReconnectionTimer { get; }
 
     #endregion
 
@@ -57,39 +125,55 @@ public sealed class PipeClient<T> : IPipeClient<T>
     /// <summary>
     /// Invoked whenever a message is received from the server.
     /// </summary>
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    public event EventHandler<ConnectionMessageEventArgs<byte[]?>>? MessageReceived;
 
     /// <summary>
     /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+    public event EventHandler<ConnectionEventArgs>? Disconnected;
 
     /// <summary>
     /// Invoked after each the client connect to the server (include reconnects).
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Connected;
+    public event EventHandler<ConnectionEventArgs>? Connected;
 
     /// <summary>
     /// Invoked whenever an exception is thrown during a read or write operation on the named pipe.
     /// </summary>
     public event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
 
-    private void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
-    {
-        MessageReceived?.Invoke(this, args);
-    }
-
-    private void OnDisconnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Calls the <see cref="Disconnected"/> event.
+    /// </summary>
+    /// <param name="args">The <see cref="ConnectionEventArgs"/> instance containing the event data.</param>
+    protected void OnDisconnected(ConnectionEventArgs args)
     {
         Disconnected?.Invoke(this, args);
     }
 
-    private void OnConnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Calls the <see cref="Connected"/> event.
+    /// </summary>
+    /// <param name="args">The <see cref="ConnectionEventArgs"/> instance containing the event data.</param>
+    protected void OnConnected(ConnectionEventArgs args)
     {
         Connected?.Invoke(this, args);
     }
+    
+    /// <summary>
+    /// Calls the <see cref="MessageReceived"/> event.
+    /// </summary>
+    /// <param name="args">The instance containing the event data.</param>
+    protected void OnMessageReceived(ConnectionMessageEventArgs<byte[]?> args)
+    {
+        MessageReceived?.Invoke(this, args);
+    }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Calls the <see cref="ExceptionOccurred"/> event.
+    /// </summary>
+    /// <param name="exception">The exception.</param>
+    protected void OnExceptionOccurred(Exception exception)
     {
         ExceptionOccurred?.Invoke(this, new ExceptionEventArgs(exception));
     }
@@ -179,18 +263,10 @@ public sealed class PipeClient<T> : IPipeClient<T>
 #pragma warning restore CA2000 // Dispose objects before losing scope
                     .ConfigureAwait(false);
 
-            Connection = new PipeConnection<T>(dataPipe, connectionPipeName, Formatter, ServerName);
-            Connection.Disconnected += async (_, args) =>
-            {
-                await DisconnectInternalAsync().ConfigureAwait(false);
-
-                OnDisconnected(args);
-            };
-            Connection.MessageReceived += (_, args) => OnMessageReceived(args);
-            Connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+            Connection = SetupPipeConnection(dataPipe, connectionPipeName, Formatter, ServerName);
             Connection.Start();
 
-            OnConnected(new ConnectionEventArgs<T>(Connection));
+            OnConnected(new ConnectionEventArgs(Connection));
         }
         catch (Exception)
         {
@@ -216,7 +292,11 @@ public sealed class PipeClient<T> : IPipeClient<T>
         await DisconnectInternalAsync().ConfigureAwait(false);
     }
 
-    private async Task DisconnectInternalAsync()
+    /// <summary>
+    /// Disconnects from the server. Does not stop <see cref="ReconnectionTimer"/>.
+    /// </summary>
+    /// <returns>A Task representing the asynchronous operation.</returns>
+    protected async Task DisconnectInternalAsync()
     {
         if (Connection == null)
         {
@@ -229,24 +309,74 @@ public sealed class PipeClient<T> : IPipeClient<T>
     }
 
     /// <summary>
+    /// Instantiates and sets up the pipe connection (event handlers, etc.).
+    /// </summary>
+    /// <param name="dataPipe">The pipe stream.</param>
+    /// <param name="connectionPipeName">Name of the connection pipe.</param>
+    /// <param name="formatter">The formatter.</param>
+    /// <param name="serverName"></param>
+    /// <returns>PipeConnection.</returns>
+    protected virtual PipeConnection SetupPipeConnection(
+        PipeStream dataPipe, string connectionPipeName, IFormatter formatter, string serverName)
+    {
+        var connection = new PipeConnection(dataPipe, connectionPipeName, formatter, serverName);
+
+        connection.Disconnected += async (_, args) =>
+        {
+            await DisconnectInternalAsync().ConfigureAwait(false);
+
+            OnDisconnected(args);
+        };
+        connection.MessageReceived   += (_, args) => OnMessageReceived(args);
+        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+
+        return connection;
+    }
+
+    /// <summary>
     /// Sends a message to the server over a named pipe. <br/>
     /// If client is not connected, <see cref="InvalidOperationException"/> is occurred
     /// </summary>
     /// <param name="value">Message to send to the server.</param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
+    {
+        await ReconnectOrThrow(cancellationToken).ConfigureAwait(false);
+
+        await Connection!.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends a message to the server over a named pipe. <br/>
+    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred
+    /// </summary>
+    /// <param name="value">Message to send to the server.</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public async Task WriteAsync<T>(T value, CancellationToken cancellationToken = default)
+    {
+        await ReconnectOrThrow(cancellationToken).ConfigureAwait(false);
+
+        await Connection!.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reconnects the client if needed and throws an exception when failed.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <exception cref="System.InvalidOperationException">Client is not connected</exception>
+    protected async Task ReconnectOrThrow(CancellationToken cancellationToken = default)
     {
         if (!IsConnected && AutoReconnect)
         {
             await ConnectAsync(cancellationToken).ConfigureAwait(false);
         }
+
         if (Connection == null)
         {
             throw new InvalidOperationException("Client is not connected");
         }
-
-        await Connection.WriteAsync(value, cancellationToken).ConfigureAwait(false);
     }
 
     #endregion
@@ -261,6 +391,8 @@ public sealed class PipeClient<T> : IPipeClient<T>
         ReconnectionTimer.Dispose();
 
         await DisconnectInternalAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
     }
 
     #endregion
@@ -286,6 +418,7 @@ public sealed class PipeClient<T> : IPipeClient<T>
 #endif
         {
             var bytes = await handshake.ReadAsync(cancellationToken).ConfigureAwait(false);
+
             if (bytes == null)
             {
                 throw new InvalidOperationException("Connection failed: Returned by server pipeName is null");

--- a/src/libs/H.Pipes/PipeConnection.cs
+++ b/src/libs/H.Pipes/PipeConnection.cs
@@ -33,7 +33,7 @@ public class PipeConnection<T> : PipeConnection
         T? obj = default;
 
         if (message != null)
-            obj = await message.DeserializeAsync<T>(Formatter, cancellationToken).ConfigureAwait(false);
+            obj = await Formatter.DeserializeAsync<T>(message, cancellationToken).ConfigureAwait(false);
 
         MessageReceived?.Invoke(this, new ConnectionMessageEventArgs<T?>(this, obj));
     }
@@ -190,7 +190,7 @@ public class PipeConnection : IPipeConnection, IAsyncDisposable
             throw new InvalidOperationException("Client is not connected");
         }
 
-        var bytes = await value.SerializeAsync(Formatter, cancellationToken).ConfigureAwait(false);
+        var bytes = await Formatter.SerializeAsync(value, cancellationToken).ConfigureAwait(false);
 
         await PipeStreamWrapper.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
     }

--- a/src/libs/H.Pipes/PipeConnection.cs
+++ b/src/libs/H.Pipes/PipeConnection.cs
@@ -1,47 +1,73 @@
 ﻿using System.IO.Pipes;
 using H.Formatters;
 using H.Pipes.Args;
+using H.Pipes.Extensions;
 using H.Pipes.IO;
 using H.Pipes.Utilities;
 
 namespace H.Pipes;
 
-/// <summary>
-/// Represents a connection between a named pipe client and server.
-/// </summary>
+/// <inheritdoc/>
 /// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class PipeConnection<T> : IAsyncDisposable
+public class PipeConnection<T> : PipeConnection
+{
+    #region Constructors
+
+    /// <inheritdoc />
+    internal PipeConnection(PipeStream stream, string pipeName, IFormatter formatter, string serverName = "")
+        : base(stream, pipeName, formatter, serverName) { }
+
+    #endregion
+
+    #region Events
+    
+    /// <summary>
+    ///     Invoked when an exception is thrown during any read/write operation over the named
+    ///     pipe.
+    /// </summary>
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <inheritdoc />
+    protected override async Task OnMessageReceived(byte[]? message, CancellationToken cancellationToken)
+    {
+        T? obj = default;
+
+        if (message != null)
+            obj = await message.DeserializeAsync<T>(Formatter, cancellationToken).ConfigureAwait(false);
+
+        MessageReceived?.Invoke(this, new ConnectionMessageEventArgs<T?>(this, obj));
+    }
+
+    #endregion
+}
+
+/// <summary>
+///     Represents a connection between a named pipe client and server. Implements the
+///     <see cref="System.IAsyncDisposable" /> Implements the
+///     <see cref="H.Pipes.IPipeConnection" />
+/// </summary>
+/// <seealso cref="System.IAsyncDisposable" />
+/// <seealso cref="H.Pipes.IPipeConnection" />
+public class PipeConnection : IPipeConnection, IAsyncDisposable
 {
     #region Properties
-
-    /// <summary>
-    /// Gets the connection's pipe name.
-    /// </summary>
+    
+    /// <inheritdoc />
     public string PipeName { get; }
-
-    /// <summary>
-    /// Gets the connection's server name. Only for client connections.
-    /// </summary>
+    
+    /// <inheritdoc />
     public string ServerName { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the pipe is connected or not.
-    /// </summary>
+    
+    /// <inheritdoc />
     public bool IsConnected => PipeStreamWrapper.IsConnected;
-
-    /// <summary>
-    /// <see langword="true"/> if started and not disposed.
-    /// </summary>
+    
+    /// <inheritdoc />
     public bool IsStarted => ReadWorker != null;
-
-    /// <summary>
-    /// Raw pipe stream. You can cast it to <see cref="NamedPipeClientStream"/> or <see cref="NamedPipeServerStream"/>.
-    /// </summary>
+    
+    /// <inheritdoc />
     public PipeStream PipeStream { get; }
 
-    /// <summary>
-    /// Used formatter.
-    /// </summary>
+    /// <inheritdoc />
     public IFormatter Formatter { get; set; }
 
     private PipeStreamWrapper PipeStreamWrapper { get; }
@@ -50,35 +76,43 @@ public sealed class PipeConnection<T> : IAsyncDisposable
     #endregion
 
     #region Events
+    
+    /// <inheritdoc />
+    public event EventHandler<ConnectionEventArgs>? Disconnected;
+    
+    /// <inheritdoc />
+    public event EventHandler<ConnectionMessageEventArgs<byte[]?>>? MessageReceived;
+    
+    /// <inheritdoc />
+    public event EventHandler<ConnectionExceptionEventArgs>? ExceptionOccurred;
 
     /// <summary>
-    /// Invoked when the named pipe connection terminates.
+    /// Calls the <see cref="Disconnected"/> event.
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Disconnected;
-
-    /// <summary>
-    /// Invoked whenever a message is received from the other end of the pipe.
-    /// </summary>
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
-
-    /// <summary>
-    /// Invoked when an exception is thrown during any read/write operation over the named pipe.
-    /// </summary>
-    public event EventHandler<ConnectionExceptionEventArgs<T>>? ExceptionOccurred;
-
-    private void OnDisconnected()
+    protected virtual void OnDisconnected()
     {
-        Disconnected?.Invoke(this, new ConnectionEventArgs<T>(this));
+        Disconnected?.Invoke(this, new ConnectionEventArgs(this));
     }
 
-    private void OnMessageReceived(T? message)
+    /// <summary>
+    /// Calls the <see cref="MessageReceived"/> event.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="cancellationToken"></param>
+    protected virtual Task OnMessageReceived(byte[]? message, CancellationToken cancellationToken)
     {
-        MessageReceived?.Invoke(this, new ConnectionMessageEventArgs<T?>(this, message));
+        MessageReceived?.Invoke(this, new ConnectionMessageEventArgs<byte[]?>(this, message));
+
+        return Task.CompletedTask;
     }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Calls the <see cref="ExceptionOccurred"/> event.
+    /// </summary>
+    /// <param name="exception">The exception.</param>
+    protected virtual void OnExceptionOccurred(Exception exception)
     {
-        ExceptionOccurred?.Invoke(this, new ConnectionExceptionEventArgs<T>(this, exception));
+        ExceptionOccurred?.Invoke(this, new ConnectionExceptionEventArgs(this, exception));
     }
 
     #endregion
@@ -98,10 +132,7 @@ public sealed class PipeConnection<T> : IAsyncDisposable
 
     #region Public methods
 
-    /// <summary>
-    /// Begins reading from and writing to the named pipe on a background thread.
-    /// This method returns immediately.
-    /// </summary>
+    /// <inheritdoc />
     public void Start()
     {
         if (IsStarted)
@@ -116,16 +147,14 @@ public sealed class PipeConnection<T> : IAsyncDisposable
                 try
                 {
                     var bytes = await PipeStreamWrapper.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+                    // We accept zero-length messages
                     if (bytes == null && !IsConnected)
                     {
                         break;
                     }
 
-                    var obj = Formatter is IAsyncFormatter asyncFormatter
-                        ? await asyncFormatter.DeserializeAsync<T>(bytes, cancellationToken).ConfigureAwait(false)
-                        : Formatter.Deserialize<T>(bytes);
-
-                    OnMessageReceived(obj);
+                    await OnMessageReceived(bytes, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -141,29 +170,32 @@ public sealed class PipeConnection<T> : IAsyncDisposable
             OnDisconnected();
         }, OnExceptionOccurred);
     }
-
-    /// <summary>
-    /// Writes the specified <paramref name="value"/> and waits other end reading
-    /// </summary>
-    /// <param name="value"></param>
-    /// <param name="cancellationToken"></param>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    
+    /// <inheritdoc />
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
     {
         if (!IsConnected || !PipeStreamWrapper.CanWrite)
         {
             throw new InvalidOperationException("Client is not connected");
         }
 
-        var bytes = Formatter is IAsyncFormatter asyncFormatter
-            ? await asyncFormatter.SerializeAsync(value, cancellationToken).ConfigureAwait(false)
-            : Formatter.Serialize(value);
+        await PipeStreamWrapper.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+    }
+    
+    /// <inheritdoc />
+    public async Task WriteAsync<T>(T value, CancellationToken cancellationToken = default)
+    {
+        if (!IsConnected || !PipeStreamWrapper.CanWrite)
+        {
+            throw new InvalidOperationException("Client is not connected");
+        }
+
+        var bytes = await value.SerializeAsync(Formatter, cancellationToken).ConfigureAwait(false);
 
         await PipeStreamWrapper.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Dispose internal resources
-    /// </summary>
+    
+    /// <inheritdoc />
     public async Task StopAsync()
     {
         if (ReadWorker != null)
@@ -175,18 +207,8 @@ public sealed class PipeConnection<T> : IAsyncDisposable
 
         await PipeStreamWrapper.StopAsync().ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Gets the user name of the client on the other end of the pipe.
-    /// </summary>
-    /// <returns>The user name of the client on the other end of the pipe.</returns>
-    /// <exception cref="InvalidOperationException"><see cref="PipeStream"/> is not <see cref="NamedPipeServerStream"/>.</exception>
-    /// <exception cref="InvalidOperationException">No pipe connections have been made yet.</exception>
-    /// <exception cref="InvalidOperationException">The connected pipe has already disconnected.</exception>
-    /// <exception cref="InvalidOperationException">The pipe handle has not been set.</exception>
-    /// <exception cref="ObjectDisposedException">The pipe is closed.</exception>
-    /// <exception cref="IOException">The pipe connection has been broken.</exception>
-    /// <exception cref="IOException">The user name of the client is longer than 19 characters.</exception>
+    
+    /// <inheritdoc />
     public string GetImpersonationUserName()
     {
         if (PipeStream is not NamedPipeServerStream serverStream)
@@ -207,6 +229,8 @@ public sealed class PipeConnection<T> : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         await StopAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
     }
 
     #endregion

--- a/src/tests/H.Pipes.Tests/BaseTests.cs
+++ b/src/tests/H.Pipes.Tests/BaseTests.cs
@@ -22,7 +22,7 @@ public static class BaseTests
             T? value = default;
 
             if (args.Message != null)
-                value = await args.Message.DeserializeAsync<T?>(server.Formatter, cancellationToken);
+                value = await server.Formatter.DeserializeAsync<T?>(args.Message, cancellationToken);
 
             var actualHash = hashFunc?.Invoke(value);
             setActualHashFunc(actualHash);

--- a/src/tests/H.Pipes.Tests/BaseTests.cs
+++ b/src/tests/H.Pipes.Tests/BaseTests.cs
@@ -1,21 +1,98 @@
 ﻿using System.Diagnostics;
 using System.Text;
 using H.Formatters;
+using H.Pipes.Extensions;
 
 namespace H.Pipes.Tests;
 
 public static class BaseTests
 {
-    public static async Task DataTestAsync<T>(IPipeServer<T> server, IPipeClient<T> client, List<T> values, Func<T?, string>? hashFunc = null, CancellationToken cancellationToken = default)
+    public static void SetupMessageReceived<T>(
+        IPipeServer                      server,
+        IPipeClient                      client,
+        Action<string?>                  setActualHashFunc,
+        Func<TaskCompletionSource<bool>> getTcsFunc,
+        Func<T?, string>?                hashFunc,
+        CancellationToken                cancellationToken)
+    {
+        server.MessageReceived += async (_, args) =>
+        {
+            Trace.WriteLine($"Server_OnMessageReceived: {args.Message}");
+
+            T? value = default;
+
+            if (args.Message != null)
+                value = await args.Message.DeserializeAsync<T?>(server.Formatter, cancellationToken);
+
+            var actualHash = hashFunc?.Invoke(value);
+            setActualHashFunc(actualHash);
+            Trace.WriteLine($"ActualHash: {actualHash}");
+
+            // ReSharper disable once AccessToModifiedClosure
+            _ = getTcsFunc().TrySetResult(true);
+        };
+
+        client.MessageReceived += (_, args) => Trace.WriteLine($"Client_OnMessageReceived: {args.Message}");
+    }
+
+    public static void SetupMessageReceived<T>(
+        IPipeServer<T>                   server,
+        IPipeClient<T>                   client,
+        Action<string?>                  setActualHashFunc,
+        Func<TaskCompletionSource<bool>> getTcsFunc,
+        Func<T?, string>?                hashFunc)
+    {
+        server.MessageReceived += (_, args) =>
+        {
+            Trace.WriteLine($"Server_OnMessageReceived: {args.Message}");
+
+            var actualHash = hashFunc?.Invoke(args.Message);
+
+            setActualHashFunc(actualHash);
+            Trace.WriteLine($"ActualHash: {actualHash}");
+
+            // ReSharper disable once AccessToModifiedClosure
+            _ = getTcsFunc().TrySetResult(true);
+        };
+
+        client.MessageReceived += (_, args) => Trace.WriteLine($"Client_OnMessageReceived: {args.Message}");
+    }
+
+    public static async Task DataTestAsync<T>(
+        IPipeServer       server,
+        IPipeClient       client,
+        List<T>           values,
+        Func<T?, string>? hashFunc          = null,
+        CancellationToken cancellationToken = default,
+        bool              useGeneric        = false)
     {
         Trace.WriteLine("Setting up test...");
 
         var completionSource = new TaskCompletionSource<bool>(false);
+
         // ReSharper disable once AccessToModifiedClosure
         using var registration = cancellationToken.Register(() => completionSource.TrySetCanceled(cancellationToken));
 
-        var actualHash = (string?)null;
+        var actualHash         = (string?)null;
         var clientDisconnected = false;
+
+
+        //
+        // Shared client/server setup
+
+        if (useGeneric)
+            SetupMessageReceived(
+                (IPipeServer<T>)server, (IPipeClient<T>)client,
+                h => actualHash = h, () => completionSource, hashFunc);
+
+        else
+            SetupMessageReceived(
+                server, client,
+                h => actualHash = h, () => completionSource, hashFunc, cancellationToken);
+
+
+        //
+        // Setup the server
 
         server.ClientConnected += (_, _) =>
         {
@@ -27,51 +104,58 @@ public static class BaseTests
             clientDisconnected = true;
 
             // ReSharper disable once AccessToModifiedClosure
-            completionSource.TrySetResult(true);
-        };
-        server.MessageReceived += (_, args) =>
-        {
-            Trace.WriteLine($"Server_OnMessageReceived: {args.Message}");
-            actualHash = hashFunc?.Invoke(args.Message);
-            Trace.WriteLine($"ActualHash: {actualHash}");
-
-            // ReSharper disable once AccessToModifiedClosure
-            completionSource.TrySetResult(true);
+            _ = completionSource.TrySetResult(true);
         };
         server.ExceptionOccurred += (_, args) =>
         {
             Trace.WriteLine($"Server exception occurred: {args.Exception}");
 
             // ReSharper disable once AccessToModifiedClosure
-            completionSource.TrySetException(args.Exception);
+            _ = completionSource.TrySetException(args.Exception);
         };
-        client.Connected += (_, _) => Trace.WriteLine("Client_OnConnected");
+
+
+        //
+        // Setup the client
+
+        client.Connected    += (_, _) => Trace.WriteLine("Client_OnConnected");
         client.Disconnected += (_, _) => Trace.WriteLine("Client_OnDisconnected");
-        client.MessageReceived += (_, args) => Trace.WriteLine($"Client_OnMessageReceived: {args.Message}");
         client.ExceptionOccurred += (_, args) =>
         {
             Trace.WriteLine($"Client exception occurred: {args.Exception}");
 
             // ReSharper disable once AccessToModifiedClosure
-            completionSource.TrySetException(args.Exception);
+            _ = completionSource.TrySetException(args.Exception);
         };
+
+
+        //
+        // Setup exception handling
+
         AppDomain.CurrentDomain.UnhandledException += (_, args) =>
         {
             if (args.ExceptionObject is Exception exception)
             {
                 // ReSharper disable once AccessToModifiedClosure
-                completionSource.TrySetException(exception);
+                _ = completionSource.TrySetException(exception);
             }
         };
-
         server.ExceptionOccurred += (_, args) => Trace.WriteLine(args.Exception.ToString());
         client.ExceptionOccurred += (_, args) => Trace.WriteLine(args.Exception.ToString());
+
+
+        //
+        // Start up the server and client
 
         await server.StartAsync(cancellationToken).ConfigureAwait(false);
         await client.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
         Trace.WriteLine("Client and server started");
         Trace.WriteLine("---");
+
+
+        //
+        // Begin testing
 
         var watcher = Stopwatch.StartNew();
 
@@ -82,7 +166,7 @@ public static class BaseTests
 
             await client.WriteAsync(value, cancellationToken).ConfigureAwait(false);
 
-            await completionSource.Task.ConfigureAwait(false);
+            _ = await completionSource.Task.ConfigureAwait(false);
 
             if (hashFunc != null)
             {
@@ -101,45 +185,112 @@ public static class BaseTests
         Trace.WriteLine("~~~~~~~~~~~~~~~~~~~~~~~~~~");
     }
 
-    public static async Task DataTestAsync<T>(List<T> values, Func<T?, string>? hashFunc = null, IFormatter? formatter = default, TimeSpan? timeout = default)
+    private static PipeServer CreateServer<T>(
+        string      pipeName,
+        IFormatter? formatter,
+        bool        useGeneric)
     {
+        return useGeneric
+            ? new PipeServer<T>(pipeName, formatter)
+            : new PipeServer(pipeName, formatter ?? new BinaryFormatter());
+    }
+
+    private static SingleConnectionPipeServer CreateSingleConnectionServer<T>(
+        string      pipeName,
+        IFormatter? formatter,
+        bool        useGeneric)
+    {
+        return useGeneric
+            ? new SingleConnectionPipeServer<T>(pipeName, formatter)
+            : new SingleConnectionPipeServer(pipeName, formatter ?? new BinaryFormatter());
+    }
+
+    private static PipeClient CreateClient<T>(
+        string      pipeName,
+        IFormatter? formatter,
+        bool        useGeneric)
+    {
+        return useGeneric
+            ? new PipeClient<T>(pipeName, formatter: formatter)
+            : new PipeClient(pipeName, formatter: formatter);
+    }
+
+    private static SingleConnectionPipeClient CreateSingleConnectionClient<T>(
+        string      pipeName,
+        IFormatter? formatter,
+        bool        useGeneric)
+    {
+        return useGeneric
+            ? new SingleConnectionPipeClient<T>(pipeName, formatter: formatter)
+            : new SingleConnectionPipeClient(pipeName, formatter: formatter);
+    }
+
+    public static async Task DataTestAsync<T>(
+        List<T>           values,
+        Func<T?, string>? hashFunc   = null,
+        IFormatter?       formatter  = default,
+        TimeSpan?         timeout    = default,
+        bool              useGeneric = false)
+    {
+        formatter ??= new BinaryFormatter();
+
         using var cancellationTokenSource = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(1));
 
         const string pipeName = "data_test_pipe";
-        await using var server = new PipeServer<T>(pipeName, formatter ?? new BinaryFormatter())
-        {
+        await using var server = CreateServer<T>(pipeName, formatter, useGeneric);
+        
 #if NET48
-            // https://github.com/HavenDV/H.Pipes/issues/6
-            WaitFreePipe = true,
+        // https://github.com/HavenDV/H.Pipes/issues/6
+        server.WaitFreePipe = true;
 #endif
-        };
-        await using var client = new PipeClient<T>(pipeName, formatter: formatter ?? new BinaryFormatter());
 
-        await DataTestAsync(server, client, values, hashFunc, cancellationTokenSource.Token);
+        await using var client = CreateClient<T>(pipeName, formatter, useGeneric);
+
+        await DataTestAsync(server, client, values, hashFunc, cancellationTokenSource.Token, useGeneric);
     }
 
-    public static async Task DataSingleTestAsync<T>(List<T> values, Func<T?, string>? hashFunc = null, IFormatter? formatter = default, TimeSpan? timeout = default)
+    public static async Task DataSingleTestAsync<T>(
+        List<T>           values,
+        Func<T?, string>? hashFunc   = null,
+        IFormatter?       formatter  = default,
+        TimeSpan?         timeout    = default,
+        bool              useGeneric = false)
     {
+        formatter ??= new BinaryFormatter();
+
         using var cancellationTokenSource = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(1));
 
-        const string pipeName = "data_test_pipe";
-        await using var server = new SingleConnectionPipeServer<T>(pipeName, formatter ?? new BinaryFormatter())
-        {
-            WaitFreePipe = true
-        };
-        await using var client = new SingleConnectionPipeClient<T>(pipeName, formatter: formatter ?? new BinaryFormatter());
+        const string    pipeName = "data_test_pipe";
+        await using var server   = CreateSingleConnectionServer<T>(pipeName, formatter, useGeneric);
+        
+#if NET48
+        // https://github.com/HavenDV/H.Pipes/issues/6
+        //server.WaitFreePipe = true;
+#endif
 
-        await DataTestAsync(server, client, values, hashFunc, cancellationTokenSource.Token);
+        await using var client = CreateSingleConnectionClient<T>(pipeName, formatter, useGeneric);
+
+        await DataTestAsync(server, client, values, hashFunc, cancellationTokenSource.Token, useGeneric);
     }
 
-    public static async Task BinaryDataTestAsync(int numBytes, int count = 1, IFormatter? formatter = default, TimeSpan? timeout = default)
+    public static async Task BinaryDataTestAsync(
+        int         numBytes,
+        int         count      = 1,
+        IFormatter? formatter  = default,
+        TimeSpan?   timeout    = default,
+        bool        useGeneric = false)
     {
-        await DataTestAsync(GenerateData(numBytes, count), Hash, formatter, timeout);
+        await DataTestAsync(GenerateData(numBytes, count), Hash, formatter, timeout, useGeneric);
     }
 
-    public static async Task BinaryDataSingleTestAsync(int numBytes, int count = 1, IFormatter? formatter = default, TimeSpan? timeout = default)
+    public static async Task BinaryDataSingleTestAsync(
+        int         numBytes,
+        int         count      = 1,
+        IFormatter? formatter  = default,
+        TimeSpan?   timeout    = default,
+        bool        useGeneric = false)
     {
-        await DataSingleTestAsync(GenerateData(numBytes, count), Hash, formatter, timeout);
+        await DataSingleTestAsync(GenerateData(numBytes, count), Hash, formatter, timeout, useGeneric);
     }
 
     #region Helper methods

--- a/src/tests/H.Pipes.Tests/DataTests.cs
+++ b/src/tests/H.Pipes.Tests/DataTests.cs
@@ -6,38 +6,44 @@ namespace H.Pipes.Tests;
 public class DataTests
 {
     [TestMethod]
-    public async Task NullTest()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task NullTest(bool useGeneric)
     {
         var values = new List<string?> { null };
         static string HashFunc(string? value) => value ?? "null";
 
-        await BaseTests.DataSingleTestAsync(values, HashFunc);
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new NewtonsoftJsonFormatter());
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new SystemTextJsonFormatter());
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new CerasFormatter());
+        await BaseTests.DataSingleTestAsync(values, HashFunc, useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new NewtonsoftJsonFormatter(), useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new SystemTextJsonFormatter(), useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new CerasFormatter(), useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task EmptyArrayTest()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task EmptyArrayTest(bool useGeneric)
     {
         var values = new List<byte[]?> { Array.Empty<byte>() };
         static string HashFunc(byte[]? value) => value?.Length.ToString() ?? "null";
 
-        await BaseTests.DataSingleTestAsync(values, HashFunc);
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new NewtonsoftJsonFormatter());
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new SystemTextJsonFormatter());
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new CerasFormatter());
+        await BaseTests.DataSingleTestAsync(values, HashFunc, useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new NewtonsoftJsonFormatter(), useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new SystemTextJsonFormatter(), useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new CerasFormatter(), useGeneric: useGeneric);
 
         values = new List<byte[]?> { null };
 
-        await BaseTests.DataSingleTestAsync(values, HashFunc);
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new NewtonsoftJsonFormatter());
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new SystemTextJsonFormatter());
-        await BaseTests.DataSingleTestAsync(values, HashFunc, new CerasFormatter());
+        await BaseTests.DataSingleTestAsync(values, HashFunc, useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new NewtonsoftJsonFormatter(), useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new SystemTextJsonFormatter(), useGeneric: useGeneric);
+        await BaseTests.DataSingleTestAsync(values, HashFunc, new CerasFormatter(), useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task EmptyArrayParallelTest()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task EmptyArrayParallelTest(bool useGeneric)
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
         var cancellationToken = cancellationTokenSource.Token;
@@ -61,105 +67,139 @@ public class DataTests
     }
 
     [TestMethod]
-    public async Task TestEmptyMessageDoesNotDisconnectClient()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestEmptyMessageDoesNotDisconnectClient(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(0);
+        await BaseTests.BinaryDataTestAsync(0, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize1B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize1B(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(1);
+        await BaseTests.BinaryDataTestAsync(1, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize2B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize2B(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(2);
+        await BaseTests.BinaryDataTestAsync(2, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize3B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize3B(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(3);
+        await BaseTests.BinaryDataTestAsync(3, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize9B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize9B(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(9);
+        await BaseTests.BinaryDataTestAsync(9, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize33B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize33B(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(33);
+        await BaseTests.BinaryDataTestAsync(33, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize1Kx3_NewtonsoftJson()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize1Kx3_NewtonsoftJson(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(1025, 3, new NewtonsoftJsonFormatter());
+        await BaseTests.BinaryDataTestAsync(1025, 3, new NewtonsoftJsonFormatter(), useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize1Kx3_SystemTextJson()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize1Kx3_SystemTextJson(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(1025, 3, new SystemTextJsonFormatter());
+        await BaseTests.BinaryDataTestAsync(1025, 3, new SystemTextJsonFormatter(), useGeneric: useGeneric);
     }
 
     //[TestMethod]
-    //public async Task TestMessageSize1Kx3_Ceras()
+    //[DataRow(true)]
+    //[DataRow(false)]
+    //public async Task TestMessageSize1Kx3_Ceras(bool useGeneric)
     //{
-    //    await BaseTests.BinaryDataTestAsync(1025, 3, new CerasFormatter());
+    //    await BaseTests.BinaryDataTestAsync(1025, 3, new CerasFormatter(), useGeneric: useGeneric);
     //}
 
     [TestMethod]
-    public async Task TestMessageSize129B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize129B(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(129);
+        await BaseTests.BinaryDataTestAsync(129, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize1K()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize1K(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(1025);
+        await BaseTests.BinaryDataTestAsync(1025, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task TestMessageSize1M()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task TestMessageSize1M(bool useGeneric)
     {
-        await BaseTests.BinaryDataTestAsync(1024 * 1024 + 1);
+        await BaseTests.BinaryDataTestAsync(1024 * 1024 + 1, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task Single_TestEmptyMessageDoesNotDisconnectClient()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task Single_TestEmptyMessageDoesNotDisconnectClient(bool useGeneric)
     {
-        await BaseTests.BinaryDataSingleTestAsync(0);
+        await BaseTests.BinaryDataSingleTestAsync(0, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task Single_TestMessageSize1B()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task Single_TestMessageSize1B(bool useGeneric)
     {
-        await BaseTests.BinaryDataSingleTestAsync(1);
+        await BaseTests.BinaryDataSingleTestAsync(1, useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task Single_TestMessageSize1Kx3_NewtonsoftJson()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task Single_TestMessageSize1Kx3_NewtonsoftJson(bool useGeneric)
     {
-        await BaseTests.BinaryDataSingleTestAsync(1025, 3, new NewtonsoftJsonFormatter());
+        await BaseTests.BinaryDataSingleTestAsync(1025, 3, new NewtonsoftJsonFormatter(), useGeneric: useGeneric);
     }
 
     [TestMethod]
-    public async Task Single_TestMessageSize1Kx3_SystemTextJson()
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task Single_TestMessageSize1Kx3_SystemTextJson(bool useGeneric)
     {
-        await BaseTests.BinaryDataSingleTestAsync(1025, 3, new SystemTextJsonFormatter());
+        await BaseTests.BinaryDataSingleTestAsync(1025, 3, new SystemTextJsonFormatter(), useGeneric: useGeneric);
     }
 
     //[TestMethod]
-    //public async Task Single_TestMessageSize1Kx3_Ceras()
+    //[DataRow(true)]
+    //[DataRow(false)]
+    //public async Task Single_TestMessageSize1Kx3_Ceras(bool useGeneric)
     //{
-    //    await BaseTests.BinaryDataSingleTestAsync(1025, 3, new CerasFormatter());
+    //    await BaseTests.BinaryDataSingleTestAsync(1025, 3, new CerasFormatter(), useGeneric: useGeneric);
     //}
 
     [TestMethod]

--- a/src/tests/H.Pipes.Tests/PipeClientTests.cs
+++ b/src/tests/H.Pipes.Tests/PipeClientTests.cs
@@ -4,17 +4,17 @@
 public class PipeClientTests
 {
     [TestMethod]
-    public async Task ConnectTest()
+    public async Task ConnectCancellationTest()
     {
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-        await using var client = new PipeClient<string>("this_pipe_100%_is_not_exists");
+        using var       cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        await using var client                  = new PipeClient("this_pipe_100%_is_not_exists");
 
         await Assert.ThrowsExceptionAsync<OperationCanceledException>(
             async () => await client.ConnectAsync(cancellationTokenSource.Token));
     }
 
     [TestMethod]
-    public async Task WriteAsyncTest()
+    public async Task WriteAsyncCancellationTest()
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var cancellationToken = cancellationTokenSource.Token;


### PR DESCRIPTION
Hello!

As discussed:

- Added: Non-generic versions of PipeServer, PipeClient, SingleConnectionPipeServer, SingleConnectionPipeClient
- Added: Tests for the new PipeXXX classes in the form of [DataRow()], see DataTests.cs
- Added: FormatterExtensions.cs which  implements extensions methods SerializeAsync and DeserializeAsync on objects
- Added: New IPipeConnection interface for PipeConnection
- Updated: Generic versions of PipeXXX inherit from their non-generic counterpart
- Updated: Renamed IPipeConnection to IPipe since all PipeXXX inherit from them (the name seemed more fitting)
- Updated: BaseTests.cs to test both the Generic and Non-generic PipeXXX versions
- Updated: Made PipeXXX non-sealed
- Updated: PipeXXX private methods and properties are now protected and documented