### PR TITLE
Fix for the issue 75

### DIFF
--- a/src/libs/H.Formatters.Inferno/H.Formatters.Inferno.csproj
+++ b/src/libs/H.Formatters.Inferno/H.Formatters.Inferno.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\H.Formatters\H.Formatters.csproj" />
+    <ProjectReference Include="..\H.Pipes.AccessControl\H.Pipes.AccessControl.csproj" />
     <ProjectReference Include="..\H.Pipes\H.Pipes.csproj" />
   </ItemGroup>
 

--- a/src/libs/H.Formatters.Inferno/PipeServerExtensions.cs
+++ b/src/libs/H.Formatters.Inferno/PipeServerExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
+using System.IO.Pipes;
 using H.Pipes;
+using H.Pipes.AccessControl;
 using H.Pipes.Extensions;
 
 namespace H.Formatters;
@@ -19,7 +21,8 @@ public static class PipeServerExtensions
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     public static void EnableEncryption<T>(
         this IPipeServer<T> server,
-        Action<Exception>? exceptionAction = null)
+        Action<Exception>? exceptionAction = null, 
+        PipeSecurity? pipeSecurity = null)
     {
         server = server ?? throw new ArgumentNullException(nameof(server));
         server.ClientConnected += async (_, args) =>
@@ -31,6 +34,11 @@ public static class PipeServerExtensions
 
                 var pipeName = $"{args.Connection.PipeName}_Inferno";
                 var server = new SingleConnectionPipeServer<byte[]>(pipeName, args.Connection.Formatter);
+
+                if (pipeSecurity != null) 
+                {
+                    server.SetPipeSecurity(pipeSecurity);
+                }
                 server.ExceptionOccurred += (_, args) =>
                 {
                     Debug.WriteLine($"{nameof(EnableEncryption)} server returns exception: {args.Exception}");

--- a/src/libs/H.Pipes.AccessControl/PipeServerExtensions.cs
+++ b/src/libs/H.Pipes.AccessControl/PipeServerExtensions.cs
@@ -11,7 +11,7 @@ public static class PipeServerExtensions
 {
     /// <summary>
     /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/> <br/>
-    /// Overrides <see cref="PipeServer{T}.CreatePipeStreamFunc"/>
+    /// Overrides <see cref="PipeServer{T}.CreatePipeStreamFunc"/> and <see cref="PipeServer{T}.CreatePipeStreamForConnectionFunc"></see>
     /// </summary>
     /// <param name="server"></param>
     /// <param name="pipeSecurity"></param>
@@ -22,8 +22,9 @@ public static class PipeServerExtensions
     {
         server = server ?? throw new ArgumentNullException(nameof(server));
         pipeSecurity = pipeSecurity ?? throw new ArgumentNullException(nameof(pipeSecurity));
-
-        server.CreatePipeStreamFunc = pipeName => NamedPipeServerStreamConstructors.New(
+#if NET6_0_OR_GREATER
+        server.CreatePipeStreamFunc = pipeName =>
+        NamedPipeServerStreamAcl.Create(
             pipeName: pipeName,
             direction: PipeDirection.InOut,
             maxNumberOfServerInstances: 1,
@@ -31,7 +32,21 @@ public static class PipeServerExtensions
             options: PipeOptions.Asynchronous | PipeOptions.WriteThrough,
             inBufferSize: 0,
             outBufferSize: 0,
-            pipeSecurity: pipeSecurity);
+            pipeSecurity);
+
+        //server.c
+#else
+       server.CreatePipeStreamFunc = pipeName =>
+           NamedPipeServerStreamConstructors.New(
+                pipeName: pipeName,
+                direction: PipeDirection.InOut,
+                maxNumberOfServerInstances: 1,
+                transmissionMode: PipeTransmissionMode.Byte,
+                options: PipeOptions.Asynchronous | PipeOptions.WriteThrough,
+                inBufferSize: 0,
+                outBufferSize: 0,
+                pipeSecurity: pipeSecurity);
+#endif
     }
 
     /// <summary>

--- a/src/libs/H.Pipes/Factories/PipeServerFactory.cs
+++ b/src/libs/H.Pipes/Factories/PipeServerFactory.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
 
 namespace H.Pipes.Factories;
 
@@ -44,7 +46,23 @@ public static class PipeServerFactory
     /// <returns></returns>
     public static NamedPipeServerStream Create(string pipeName)
     {
-        return new NamedPipeServerStream(
+#if NET6_0_OR_GREATER
+ 
+#pragma warning disable CA1416
+        return NamedPipeServerStreamAcl.Create(
+            pipeName: pipeName,
+            direction: PipeDirection.InOut,
+            maxNumberOfServerInstances: 1,
+            transmissionMode: PipeTransmissionMode.Byte,
+            options: PipeOptions.Asynchronous | PipeOptions.WriteThrough,
+            inBufferSize: 0,
+            outBufferSize: 0,
+            null,
+            HandleInheritability.None,
+            (PipeAccessRights)0);
+#pragma warning restore CA1416
+#else
+ return new NamedPipeServerStream(
             pipeName: pipeName,
             direction: PipeDirection.InOut,
             maxNumberOfServerInstances: 1,
@@ -52,5 +70,7 @@ public static class PipeServerFactory
             options: PipeOptions.Asynchronous | PipeOptions.WriteThrough,
             inBufferSize: 0,
             outBufferSize: 0);
+#endif
+
     }
 }

--- a/src/libs/H.Pipes/IO/PipeStreamWriter.cs
+++ b/src/libs/H.Pipes/IO/PipeStreamWriter.cs
@@ -20,7 +20,7 @@ public sealed class PipeStreamWriter : IDisposable
     /// Gets the underlying <c>PipeStream</c> object.
     /// </summary>
     private PipeStream BaseStream { get; }
-    private SemaphoreSlim SemaphoreSlim { get; } = new SemaphoreSlim(1, 1);
+    private SemaphoreSlim SemaphoreSlim { get; } = new(1, 1);
 
     #endregion
 


### PR DESCRIPTION
Addressing the latest changes to the NamedPipesServer instantiation with the custom PipeSecurity object for .NET 6 - .NET 8.