### PR TITLE
[codex] Document samples and stabilize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ Install-Package H.Formatters.System.Text.Json
 Install-Package H.Formatters.Ceras
 ```
 
+### Samples
+
+The repository contains small runnable samples under `src/samples`:
+
+- `ConsoleApp` shows a basic strongly-typed client/server exchange using the default formatter.
+- `H.Pipes.Apps.ConsoleApp.MessagePack` shows the same client/server pattern with MessagePack serialization.
+- `H.Pipes.Apps.ConsoleApp.Inferno` shows encrypted communication with `H.Formatters.Inferno`.
+- `H.Pipes.Apps.ConsoleApp.Polly` shows reconnect/retry-style usage with Polly.
+- `WindowsFormsApp` shows how to run the server and client from a Windows Forms UI.
+
+Run a sample from the repository root with `dotnet run --project <sample csproj>`. For example:
+
+```shell
+dotnet run --project src/samples/ConsoleApp/ConsoleApp.csproj
+dotnet run --project src/samples/H.Pipes.Apps.ConsoleApp.MessagePack/H.Pipes.Apps.ConsoleApp.MessagePack.csproj
+```
+
 ### Usage
 
 Server:

--- a/src/tests/H.Pipes.Tests/BaseTests.cs
+++ b/src/tests/H.Pipes.Tests/BaseTests.cs
@@ -6,6 +6,11 @@ namespace H.Pipes.Tests;
 
 public static class BaseTests
 {
+    public static string CreatePipeName(string prefix = "pipe")
+    {
+        return $"{prefix}_{Guid.NewGuid():N}";
+    }
+
     public static async Task DataTestAsync<T>(IPipeServer<T> server, IPipeClient<T> client, List<T> values, Func<T?, string>? hashFunc = null, CancellationToken cancellationToken = default)
     {
         Trace.WriteLine("Setting up test...");
@@ -105,7 +110,7 @@ public static class BaseTests
     {
         using var cancellationTokenSource = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(1));
 
-        const string pipeName = "pipe";
+        var pipeName = CreatePipeName();
         await using var server = new PipeServer<T>(pipeName, formatter ?? new DefaultFormatter())
         {
 #if NET48
@@ -122,7 +127,7 @@ public static class BaseTests
     {
         using var cancellationTokenSource = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(1));
 
-        const string pipeName = "pipe";
+        var pipeName = CreatePipeName();
         await using var server = new SingleConnectionPipeServer<T>(pipeName, formatter ?? new DefaultFormatter())
         {
             WaitFreePipe = true

--- a/src/tests/H.Pipes.Tests/DataTests.cs
+++ b/src/tests/H.Pipes.Tests/DataTests.cs
@@ -42,7 +42,7 @@ public class DataTests
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
         var cancellationToken = cancellationTokenSource.Token;
 
-        const string pipeName = "pipe";
+        var pipeName = BaseTests.CreatePipeName();
         await using var server = new SingleConnectionPipeServer<string?>(pipeName)
         {
             WaitFreePipe = true
@@ -170,7 +170,7 @@ public class DataTests
         var completionSource = new TaskCompletionSource<bool>(false);
         using var registration = cancellationTokenSource.Token.Register(() => completionSource.TrySetCanceled());
 
-        const string pipeName = "pipe";
+        var pipeName = BaseTests.CreatePipeName();
         var formatter = new DefaultFormatter();
         await using var server = new PipeServer<object>(pipeName, formatter);
         await using var client = new PipeClient<object>(pipeName, formatter: formatter);

--- a/src/tests/H.Pipes.Tests/PipeClientTests.cs
+++ b/src/tests/H.Pipes.Tests/PipeClientTests.cs
@@ -7,9 +7,9 @@ public class PipeClientTests
     public async Task ConnectTest()
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-        await using var client = new PipeClient<string>("this_pipe_100%_is_not_exists");
+        await using var client = new PipeClient<string>(BaseTests.CreatePipeName("missing_pipe"));
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
             async () => await client.ConnectAsync(cancellationTokenSource.Token));
     }
 
@@ -19,7 +19,7 @@ public class PipeClientTests
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var cancellationToken = cancellationTokenSource.Token;
 
-        await using var client = new PipeClient<string>("this_pipe_100%_is_not_exists");
+        await using var client = new PipeClient<string>(BaseTests.CreatePipeName("missing_pipe"));
 
         var firstTask = Task.Run(async () =>
         {
@@ -36,11 +36,11 @@ public class PipeClientTests
             using var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             source.CancelAfter(TimeSpan.FromSeconds(1));
 
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+            await Assert.ThrowsExactlyAsync<OperationCanceledException>(
                 async () => await client.WriteAsync(string.Empty, source.Token));
         }
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
             async () => await firstTask);
     }
 }

--- a/src/tests/H.Pipes.Tests/PipeServerTests.cs
+++ b/src/tests/H.Pipes.Tests/PipeServerTests.cs
@@ -8,14 +8,16 @@ public class PipeServerTests
     [TestMethod]
     public async Task DisposeTest()
     {
+        var pipeName = BaseTests.CreatePipeName("test");
+
         {
             try
             {
                 using var source = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 #if !NETFRAMEWORK
-                await using var pipe = await PipeServerFactory.CreateAndWaitAsync("test", source.Token).ConfigureAwait(false);
+                await using var pipe = await PipeServerFactory.CreateAndWaitAsync(pipeName, source.Token).ConfigureAwait(false);
 #else
-                using var pipe = await PipeServerFactory.CreateAndWaitAsync("test", source.Token).ConfigureAwait(false);
+                using var pipe = await PipeServerFactory.CreateAndWaitAsync(pipeName, source.Token).ConfigureAwait(false);
 #endif
             }
             catch (OperationCanceledException)
@@ -25,9 +27,9 @@ public class PipeServerTests
 
         {
 #if !NETFRAMEWORK
-            await using var pipe = PipeServerFactory.Create("test");
+            await using var pipe = PipeServerFactory.Create(pipeName);
 #else
-            using var pipe = PipeServerFactory.Create("test");
+            using var pipe = PipeServerFactory.Create(pipeName);
 #endif
         }
     }
@@ -35,15 +37,17 @@ public class PipeServerTests
     [TestMethod]
     public async Task StartDisposeStart()
     {
+        var pipeName = BaseTests.CreatePipeName("test");
+
         {
-            await using var pipe = new PipeServer<string>("test");
+            await using var pipe = new PipeServer<string>(pipeName);
             await pipe.StartAsync();
         }
 
         await Task.Delay(TimeSpan.FromMilliseconds(1));
 
         {
-            await using var pipe = new PipeServer<string>("test");
+            await using var pipe = new PipeServer<string>(pipeName);
             await pipe.StartAsync();
         }
     }
@@ -51,19 +55,22 @@ public class PipeServerTests
     [TestMethod]
     public async Task DoubleStartWithSameName()
     {
-        await using var pipe1 = new PipeServer<string>("test");
+        var pipeName = BaseTests.CreatePipeName("test");
+
+        await using var pipe1 = new PipeServer<string>(pipeName);
 
         await pipe1.StartAsync();
 
-        await using var pipe2 = new PipeServer<string>("test");
+        await using var pipe2 = new PipeServer<string>(pipeName);
 
-        await Assert.ThrowsExceptionAsync<IOException>(async () => await pipe2.StartAsync());
+        await Assert.ThrowsExactlyAsync<IOException>(async () => await pipe2.StartAsync());
     }
 
     [TestMethod]
     public async Task StartStopStart()
     {
-        await using var pipe = new PipeServer<string>("test");
+        var pipeName = BaseTests.CreatePipeName("test");
+        await using var pipe = new PipeServer<string>(pipeName);
 
         await pipe.StartAsync();
         await pipe.StopAsync();

--- a/src/tests/H.Pipes.Tests/SerializableTests.cs
+++ b/src/tests/H.Pipes.Tests/SerializableTests.cs
@@ -7,7 +7,7 @@ namespace H.Pipes.Tests;
 [TestClass]
 public class SerializableTests
 {
-    private const string PipeName = "pipe";
+    private readonly string _pipeName = BaseTests.CreatePipeName(nameof(SerializableTests));
 
     private PipeServer<TestCollection>? _server;
     private PipeClient<TestCollection>? _client;
@@ -31,8 +31,8 @@ public class SerializableTests
         _barrier.Reset();
         _exceptions.Clear();
 
-        _server = new PipeServer<TestCollection>(PipeName);
-        _client = new PipeClient<TestCollection>(PipeName);
+        _server = new PipeServer<TestCollection>(_pipeName);
+        _client = new PipeClient<TestCollection>(_pipeName);
 
         _actualData = null;
         _actualHash = 0;

--- a/src/tests/H.Pipes.Tests/SingleConnectionPipeClientTests.cs
+++ b/src/tests/H.Pipes.Tests/SingleConnectionPipeClientTests.cs
@@ -7,17 +7,18 @@ public class SingleConnectionPipeClientTests
     public async Task ClientConnectCancellationTest()
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-        await using var client = new SingleConnectionPipeClient<string>("this_pipe_100%_is_not_exists");
+        await using var client = new SingleConnectionPipeClient<string>(BaseTests.CreatePipeName("missing_pipe"));
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => await client.ConnectAsync(cancellationTokenSource.Token));
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () => await client.ConnectAsync(cancellationTokenSource.Token));
     }
 
     [TestMethod]
     public async Task ClientConnectTest()
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-        await using var client = new SingleConnectionPipeClient<string>(nameof(ClientConnectTest));
-        await using var server = new SingleConnectionPipeServer<string>(nameof(ClientConnectTest));
+        var pipeName = BaseTests.CreatePipeName(nameof(ClientConnectTest));
+        await using var client = new SingleConnectionPipeClient<string>(pipeName);
+        await using var server = new SingleConnectionPipeServer<string>(pipeName);
 
         await server.StartAsync(cancellationToken: cancellationTokenSource.Token);
 
@@ -28,8 +29,9 @@ public class SingleConnectionPipeClientTests
     public async Task ClientDoubleConnectTest()
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await using var client = new SingleConnectionPipeClient<string>(nameof(ClientDoubleConnectTest));
-        await using var server = new SingleConnectionPipeServer<string>(nameof(ClientDoubleConnectTest));
+        var pipeName = BaseTests.CreatePipeName(nameof(ClientDoubleConnectTest));
+        await using var client = new SingleConnectionPipeClient<string>(pipeName);
+        await using var server = new SingleConnectionPipeServer<string>(pipeName);
 
         await server.StartAsync(cancellationToken: cancellationTokenSource.Token);
 

--- a/src/tests/H.Pipes.Tests/SingleConnectionPipeServerTests.cs
+++ b/src/tests/H.Pipes.Tests/SingleConnectionPipeServerTests.cs
@@ -6,8 +6,10 @@ public class SingleConnectionPipeServerTests
     [TestMethod]
     public async Task StartDisposeStart()
     {
+        var pipeName = BaseTests.CreatePipeName("test");
+
         {
-            await using var pipe = new SingleConnectionPipeServer<string>("test");
+            await using var pipe = new SingleConnectionPipeServer<string>(pipeName);
 
             await pipe.StartAsync();
         }
@@ -15,7 +17,7 @@ public class SingleConnectionPipeServerTests
         await Task.Delay(TimeSpan.FromMilliseconds(1));
 
         {
-            await using var pipe = new SingleConnectionPipeServer<string>("test");
+            await using var pipe = new SingleConnectionPipeServer<string>(pipeName);
 
             await pipe.StartAsync();
         }
@@ -24,19 +26,22 @@ public class SingleConnectionPipeServerTests
     [TestMethod]
     public async Task DoubleStartWithSameName()
     {
-        await using var pipe1 = new SingleConnectionPipeServer<string>("test");
+        var pipeName = BaseTests.CreatePipeName("test");
+
+        await using var pipe1 = new SingleConnectionPipeServer<string>(pipeName);
 
         await pipe1.StartAsync();
 
-        await using var pipe2 = new SingleConnectionPipeServer<string>("test");
+        await using var pipe2 = new SingleConnectionPipeServer<string>(pipeName);
 
-        await Assert.ThrowsExceptionAsync<IOException>(async () => await pipe2.StartAsync());
+        await Assert.ThrowsExactlyAsync<IOException>(async () => await pipe2.StartAsync());
     }
 
     [TestMethod]
     public async Task StartStopStart()
     {
-        await using var pipe = new SingleConnectionPipeServer<string>("test");
+        var pipeName = BaseTests.CreatePipeName("test");
+        await using var pipe = new SingleConnectionPipeServer<string>(pipeName);
 
         await pipe.StartAsync();
         await pipe.StopAsync();


### PR DESCRIPTION
## Summary

- Add a README samples section that explains the sample projects and how to run them.
- Update MSTest async exception assertions for MSTest 4.
- Give pipe-based tests unique pipe names so multi-target test runs do not collide across `net4.8` and `net9.0`.

Fixes #117.

## Validation

- `dotnet build H.Pipes.sln --configuration Release`
- `dotnet test H.Pipes.sln --configuration Release --no-build`