### PR TITLE
[codex] Shorten test pipe names for macOS

### DIFF
--- a/src/tests/H.Pipes.Tests/AssemblyAttributes.cs
+++ b/src/tests/H.Pipes.Tests/AssemblyAttributes.cs
@@ -1,0 +1,1 @@
+[assembly: DoNotParallelize]

--- a/src/tests/H.Pipes.Tests/BaseTests.cs
+++ b/src/tests/H.Pipes.Tests/BaseTests.cs
@@ -8,7 +8,23 @@ public static class BaseTests
 {
     public static string CreatePipeName(string prefix = "pipe")
     {
-        return $"{prefix}_{Guid.NewGuid():N}";
+        var first = string.IsNullOrWhiteSpace(prefix) ? 'p' : char.ToLowerInvariant(prefix[0]);
+        if (!char.IsLetterOrDigit(first))
+        {
+            first = 'p';
+        }
+
+#if NETFRAMEWORK
+        const char target = '4';
+#elif NET9_0_OR_GREATER
+        const char target = '9';
+#elif NET8_0_OR_GREATER
+        const char target = '8';
+#else
+        const char target = 'n';
+#endif
+
+        return $"{first}{target}";
     }
 
     public static async Task DataTestAsync<T>(IPipeServer<T> server, IPipeClient<T> client, List<T> values, Func<T?, string>? hashFunc = null, CancellationToken cancellationToken = default)

--- a/src/tests/H.Pipes.Tests/Tests.cs
+++ b/src/tests/H.Pipes.Tests/Tests.cs
@@ -5,8 +5,6 @@ using System.Net;
 using System.Security.AccessControl;
 using System.Security.Principal;
 
-[assembly: DoNotParallelize]
-
 namespace H.Pipes.Tests;
 
 // ReSharper disable AccessToDisposedClosure


### PR DESCRIPTION
## Summary

- Replace GUID-length test pipe names with short target-specific names so the Unix domain socket path stays below macOS limits after H.Pipes appends its connection GUID.
- Move `DoNotParallelize` to a shared assembly attribute so both test target frameworks avoid pipe-name contention.

## Root Cause

PR #144 changed tests to use GUID-based pipe names to avoid Windows cross-target collisions, but on macOS .NET named pipes are backed by Unix domain sockets with a short path-length limit. The generated path exceeded the 104-character maximum.

## Validation

- `dotnet build H.Pipes.sln --configuration Release`
- `dotnet test H.Pipes.sln --configuration Release --no-build`