### PR TITLE
[codex] Add non-generic pipe APIs

### DIFF
--- a/src/libs/H.Pipes.AccessControl/PipeServerExtensions.cs
+++ b/src/libs/H.Pipes.AccessControl/PipeServerExtensions.cs
@@ -5,24 +5,16 @@ using System.Security.Principal;
 namespace H.Pipes.AccessControl;
 
 /// <summary>
-/// Adds AccessControl extensions methods for <see cref="PipeServer{T}"/>
+/// Adds AccessControl extensions methods for <see cref="PipeServer"/>.
 /// </summary>
 public static class PipeServerExtensions
 {
-    /// <summary>
-    /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/> <br/>
-    /// Overrides <see cref="PipeServer{T}.CreatePipeStreamFunc"/> and <see cref="PipeServer{T}.CreatePipeStreamForConnectionFunc"></see>
-    /// </summary>
-    /// <param name="server"></param>
-    /// <param name="pipeSecurity"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <returns></returns>
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-    public static void SetPipeSecurity<T>(this IPipeServer<T> server, PipeSecurity pipeSecurity)
+    private static Func<string, NamedPipeServerStream> CreatePipeStreamFunc(PipeSecurity pipeSecurity)
     {
-        server = server ?? throw new ArgumentNullException(nameof(server));
         pipeSecurity = pipeSecurity ?? throw new ArgumentNullException(nameof(pipeSecurity));
-        server.CreatePipeStreamFunc = pipeName =>
+
+        return pipeName =>
 #if NET6_0_OR_GREATER
             NamedPipeServerStreamAcl.Create(
                 pipeName: pipeName,
@@ -47,8 +39,92 @@ public static class PipeServerExtensions
     }
 
     /// <summary>
-    /// Adds <see cref="PipeAccessRule"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/>
+    /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer"/> <br/>
+    /// Overrides <see cref="PipeServer.CreatePipeStreamFunc"/> and <see cref="PipeServer.CreatePipeStreamForConnectionFunc"></see>
     /// </summary>
+    /// <param name="server"></param>
+    /// <param name="pipeSecurity"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void SetPipeSecurity(this IPipeServer server, PipeSecurity pipeSecurity)
+    {
+        server = server ?? throw new ArgumentNullException(nameof(server));
+
+        server.CreatePipeStreamFunc = CreatePipeStreamFunc(pipeSecurity);
+    }
+
+    /// <summary>
+    /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/> <br/>
+    /// Overrides the server's pipe stream creation delegate.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <param name="pipeSecurity"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void SetPipeSecurity<T>(this IPipeServer<T> server, PipeSecurity pipeSecurity)
+    {
+        server = server ?? throw new ArgumentNullException(nameof(server));
+
+        server.CreatePipeStreamFunc = CreatePipeStreamFunc(pipeSecurity);
+    }
+
+    /// <summary>
+    /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <param name="pipeSecurity"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void SetPipeSecurity<T>(this PipeServer<T> server, PipeSecurity pipeSecurity)
+    {
+        SetPipeSecurity((IPipeServer)server, pipeSecurity);
+    }
+
+    /// <summary>
+    /// Sets <see cref="PipeSecurity"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="SingleConnectionPipeServer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <param name="pipeSecurity"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void SetPipeSecurity<T>(this SingleConnectionPipeServer<T> server, PipeSecurity pipeSecurity)
+    {
+        SetPipeSecurity((IPipeServer)server, pipeSecurity);
+    }
+
+    /// <summary>
+    /// Adds <see cref="PipeAccessRule"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer"/>.
+    /// </summary>
+    /// <param name="server"></param>
+    /// <param name="rules"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void AddAccessRules(this IPipeServer server, params PipeAccessRule[] rules)
+    {
+        server = server ?? throw new ArgumentNullException(nameof(server));
+        rules = rules ?? throw new ArgumentNullException(nameof(rules));
+
+        var pipeSecurity = new PipeSecurity();
+        foreach (var rule in rules)
+        {
+            pipeSecurity.AddAccessRule(rule);
+        }
+
+        server.SetPipeSecurity(pipeSecurity);
+    }
+
+    /// <summary>
+    /// Adds <see cref="PipeAccessRule"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     /// <param name="server"></param>
     /// <param name="rules"></param>
     /// <exception cref="ArgumentNullException"></exception>
@@ -69,8 +145,55 @@ public static class PipeServerExtensions
     }
 
     /// <summary>
+    /// Adds <see cref="PipeAccessRule"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="PipeServer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <param name="rules"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void AddAccessRules<T>(this PipeServer<T> server, params PipeAccessRule[] rules)
+    {
+        AddAccessRules((IPipeServer)server, rules);
+    }
+
+    /// <summary>
+    /// Adds <see cref="PipeAccessRule"/>'s for each <see cref="NamedPipeServerStream"/> that will be created by <see cref="SingleConnectionPipeServer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <param name="rules"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void AddAccessRules<T>(this SingleConnectionPipeServer<T> server, params PipeAccessRule[] rules)
+    {
+        AddAccessRules((IPipeServer)server, rules);
+    }
+
+    /// <summary>
     /// Adds <see cref="PipeAccessRule"/> that allow ReadWrite to BuiltinUsersSid.
     /// </summary>
+    /// <param name="server"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void AllowUsersReadWrite(this IPipeServer server)
+    {
+        server = server ?? throw new ArgumentNullException(nameof(server));
+
+        server.AddAccessRules(
+            new PipeAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null),
+                PipeAccessRights.ReadWrite,
+                AccessControlType.Allow));
+    }
+
+    /// <summary>
+    /// Adds <see cref="PipeAccessRule"/> that allow ReadWrite to BuiltinUsersSid.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     /// <param name="server"></param>
     /// <exception cref="ArgumentNullException"></exception>
     /// <returns></returns>
@@ -84,5 +207,31 @@ public static class PipeServerExtensions
                 new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null),
                 PipeAccessRights.ReadWrite,
                 AccessControlType.Allow));
+    }
+
+    /// <summary>
+    /// Adds <see cref="PipeAccessRule"/> that allow ReadWrite to BuiltinUsersSid.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void AllowUsersReadWrite<T>(this PipeServer<T> server)
+    {
+        AllowUsersReadWrite((IPipeServer)server);
+    }
+
+    /// <summary>
+    /// Adds <see cref="PipeAccessRule"/> that allow ReadWrite to BuiltinUsersSid.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="server"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <returns></returns>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void AllowUsersReadWrite<T>(this SingleConnectionPipeServer<T> server)
+    {
+        AllowUsersReadWrite((IPipeServer)server);
     }
 }

--- a/src/libs/H.Pipes/Args/ConnectionEventArgs.cs
+++ b/src/libs/H.Pipes/Args/ConnectionEventArgs.cs
@@ -1,21 +1,41 @@
-﻿namespace H.Pipes.Args;
+namespace H.Pipes.Args;
 
 /// <summary>
 /// Handles new connections.
 /// </summary>
-/// <typeparam name="T">Reference type</typeparam>
-public class ConnectionEventArgs<T> : EventArgs
+public class ConnectionEventArgs : EventArgs
 {
     /// <summary>
-    /// Connection
+    /// Connection.
     /// </summary>
-    public PipeConnection<T> Connection { get; }
+    public PipeConnection Connection { get; }
 
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="ConnectionEventArgs"/> class.
     /// </summary>
     /// <param name="connection"></param>
-    public ConnectionEventArgs(PipeConnection<T> connection)
+    public ConnectionEventArgs(PipeConnection connection)
+    {
+        Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+    }
+}
+
+/// <summary>
+/// Handles new connections.
+/// </summary>
+/// <typeparam name="T">Reference type.</typeparam>
+public class ConnectionEventArgs<T> : ConnectionEventArgs
+{
+    /// <summary>
+    /// Connection.
+    /// </summary>
+    public new PipeConnection<T> Connection { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionEventArgs{T}"/> class.
+    /// </summary>
+    /// <param name="connection"></param>
+    public ConnectionEventArgs(PipeConnection<T> connection) : base(connection)
     {
         Connection = connection ?? throw new ArgumentNullException(nameof(connection));
     }

--- a/src/libs/H.Pipes/Args/ConnectionExceptionEventArgs.cs
+++ b/src/libs/H.Pipes/Args/ConnectionExceptionEventArgs.cs
@@ -1,18 +1,39 @@
-﻿namespace H.Pipes.Args;
+namespace H.Pipes.Args;
 
 /// <summary>
 /// Handles exceptions thrown during read/write operations.
 /// </summary>
-/// <typeparam name="T">Reference type</typeparam>
-public class ConnectionExceptionEventArgs<T> : ConnectionEventArgs<T>
+public class ConnectionExceptionEventArgs : ConnectionEventArgs
 {
     /// <summary>
-    /// The exception that was thrown
+    /// The exception that was thrown.
     /// </summary>
     public Exception Exception { get; }
 
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="ConnectionExceptionEventArgs"/> class.
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="exception"></param>
+    public ConnectionExceptionEventArgs(PipeConnection connection, Exception exception) : base(connection)
+    {
+        Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+    }
+}
+
+/// <summary>
+/// Handles exceptions thrown during read/write operations.
+/// </summary>
+/// <typeparam name="T">Reference type.</typeparam>
+public class ConnectionExceptionEventArgs<T> : ConnectionEventArgs<T>
+{
+    /// <summary>
+    /// The exception that was thrown.
+    /// </summary>
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionExceptionEventArgs{T}"/> class.
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="exception"></param>

--- a/src/libs/H.Pipes/Args/ConnectionMessageEventArgs.cs
+++ b/src/libs/H.Pipes/Args/ConnectionMessageEventArgs.cs
@@ -1,18 +1,40 @@
-﻿namespace H.Pipes.Args;
+namespace H.Pipes.Args;
 
 /// <summary>
 /// Handles messages received from a named pipe.
 /// </summary>
-/// <typeparam name="T">Reference type</typeparam>
+public class ConnectionMessageEventArgs : ConnectionEventArgs
+{
+    /// <summary>
+    /// Message sent by the other end of the pipe.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "The non-generic pipe API exposes raw byte messages.")]
+    public byte[]? Message { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionMessageEventArgs"/> class.
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="message"></param>
+    public ConnectionMessageEventArgs(PipeConnection connection, byte[]? message) : base(connection)
+    {
+        Message = message;
+    }
+}
+
+/// <summary>
+/// Handles messages received from a named pipe.
+/// </summary>
+/// <typeparam name="T">Reference type.</typeparam>
 public class ConnectionMessageEventArgs<T> : ConnectionEventArgs<T>
 {
     /// <summary>
-    /// Message sent by the other end of the pipe
+    /// Message sent by the other end of the pipe.
     /// </summary>
     public T Message { get; }
 
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="ConnectionMessageEventArgs{T}"/> class.
     /// </summary>
     /// <param name="connection"></param>
     /// <param name="message"></param>

--- a/src/libs/H.Pipes/Extensions/ConnectionExtensions.cs
+++ b/src/libs/H.Pipes/Extensions/ConnectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ConnectionExtensions
     public static async Task<ConnectionMessageEventArgs<T>> WaitMessageAsync<T>(this IPipeConnection<T> connection, Func<CancellationToken, Task>? func = null, CancellationToken cancellationToken = default)
     {
         return await connection.WaitEventAsync<ConnectionMessageEventArgs<T>>(
-            func ?? (token => Task.Delay(TimeSpan.Zero, cancellationToken)),
+            func ?? (token => Task.Delay(TimeSpan.Zero, token)),
             nameof(connection.MessageReceived),
             cancellationToken).ConfigureAwait(false);
     }

--- a/src/libs/H.Pipes/IO/PipeStreamReader.cs
+++ b/src/libs/H.Pipes/IO/PipeStreamReader.cs
@@ -101,7 +101,7 @@ public sealed class PipeStreamReader : IDisposable
         var length = await ReadLengthAsync(cancellationToken).ConfigureAwait(false);
 
         return length == 0
-            ? default
+            ? IsConnected ? Array.Empty<byte>() : default
             : await ReadAsync(
                 length: length,
                 throwIfReadLessThanLength: true,

--- a/src/libs/H.Pipes/IPipeClient.cs
+++ b/src/libs/H.Pipes/IPipeClient.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using H.Pipes.Args;
 
 namespace H.Pipes;
@@ -6,15 +6,14 @@ namespace H.Pipes;
 /// <summary>
 /// Wraps a <see cref="NamedPipeClientStream"/>.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public interface IPipeClient<T> : IPipeConnection<T>
+public interface IPipeClient : IPipeConnection
 {
     #region Properties
 
     /// <summary>
     /// Used pipe name.
     /// </summary>
-    public string PipeName { get; }
+    string PipeName { get; }
 
     /// <summary>
     /// First argument: pipeName, Second argument: serverName.
@@ -34,7 +33,7 @@ public interface IPipeClient<T> : IPipeConnection<T>
     TimeSpan ReconnectionInterval { get; }
 
     /// <summary>
-    /// Checks that connection is exists.
+    /// Checks that connection exists.
     /// </summary>
     bool IsConnected { get; }
 
@@ -46,24 +45,108 @@ public interface IPipeClient<T> : IPipeConnection<T>
     /// <summary>
     /// Used server name.
     /// </summary>
-    public string ServerName { get; }
+    string ServerName { get; }
 
     /// <summary>
     /// Active connection.
     /// </summary>
-    public PipeConnection<T>? Connection { get; }
+    PipeConnection? Connection { get; }
 
     #endregion
 
     #region Events
 
     /// <summary>
-    /// Invoked after each the client connect to the server (include reconnects).
+    /// Invoked after each client connection to the server, including reconnects.
+    /// </summary>
+    event EventHandler<ConnectionEventArgs>? Connected;
+
+    /// <summary>
+    /// Invoked when the client disconnects from the server.
+    /// </summary>
+    event EventHandler<ConnectionEventArgs>? Disconnected;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Connects to the named pipe server asynchronously.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    Task ConnectAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Disconnects from server.
+    /// </summary>
+    /// <param name="_"></param>
+    /// <returns></returns>
+    Task DisconnectAsync(CancellationToken _ = default);
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeClientStream"/>.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
+public interface IPipeClient<T> : IPipeConnection<T>
+{
+    #region Properties
+
+    /// <summary>
+    /// Used pipe name.
+    /// </summary>
+    string PipeName { get; }
+
+    /// <summary>
+    /// First argument: pipeName, Second argument: serverName.
+    /// </summary>
+    Func<string, string, NamedPipeClientStream>? CreatePipeStreamFunc { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the client should attempt to reconnect when the pipe breaks
+    /// due to an error or the other end terminating the connection. <br/>
+    /// Default value is <see langword="true"/>.
+    /// </summary>
+    bool AutoReconnect { get; set; }
+
+    /// <summary>
+    /// Interval of reconnection.
+    /// </summary>
+    TimeSpan ReconnectionInterval { get; }
+
+    /// <summary>
+    /// Checks that connection exists.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// <see langword="true"/> if <see cref="ConnectAsync"/> in process.
+    /// </summary>
+    bool IsConnecting { get; }
+
+    /// <summary>
+    /// Used server name.
+    /// </summary>
+    string ServerName { get; }
+
+    /// <summary>
+    /// Active connection.
+    /// </summary>
+    PipeConnection<T>? Connection { get; }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Invoked after each client connection to the server, including reconnects.
     /// </summary>
     event EventHandler<ConnectionEventArgs<T>>? Connected;
 
     /// <summary>
-    /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
+    /// Invoked when the client disconnects from the server.
     /// </summary>
     event EventHandler<ConnectionEventArgs<T>>? Disconnected;
 
@@ -78,7 +161,7 @@ public interface IPipeClient<T> : IPipeConnection<T>
     Task ConnectAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Disconnects from server
+    /// Disconnects from server.
     /// </summary>
     /// <param name="_"></param>
     /// <returns></returns>

--- a/src/libs/H.Pipes/IPipeConnection.cs
+++ b/src/libs/H.Pipes/IPipeConnection.cs
@@ -1,20 +1,52 @@
-﻿using H.Formatters;
+using H.Formatters;
 using H.Pipes.Args;
 
 namespace H.Pipes;
 
 /// <summary>
-/// Base class of all connections
+/// Base interface for raw byte pipe connections.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
+public interface IPipeConnection : IAsyncDisposable
+{
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a message is received.
+    /// </summary>
+    event EventHandler<ConnectionMessageEventArgs>? MessageReceived;
+
+    /// <summary>
+    /// Invoked whenever an exception is thrown during a read or write operation on the named pipe.
+    /// </summary>
+    event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Sends a message over a named pipe.
+    /// </summary>
+    /// <param name="value">Message to send.</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    Task WriteAsync(byte[] value, CancellationToken cancellationToken = default);
+
+    #endregion
+}
+
+/// <summary>
+/// Base interface for typed pipe connections.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
 public interface IPipeConnection<T> : IAsyncDisposable
 {
     #region Properties
 
     /// <summary>
-    /// Used formatter
+    /// Used formatter.
     /// </summary>
-    public IFormatter Formatter { get; }
+    IFormatter Formatter { get; }
 
     #endregion
 
@@ -35,9 +67,9 @@ public interface IPipeConnection<T> : IAsyncDisposable
     #region Methods
 
     /// <summary>
-    /// Sends a message over a named pipe. <br/>
+    /// Sends a message over a named pipe.
     /// </summary>
-    /// <param name="value">Message to send</param>
+    /// <param name="value">Message to send.</param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="InvalidOperationException"></exception>
     Task WriteAsync(T value, CancellationToken cancellationToken = default);

--- a/src/libs/H.Pipes/IPipeServer.cs
+++ b/src/libs/H.Pipes/IPipeServer.cs
@@ -1,33 +1,94 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using H.Pipes.Args;
 
 namespace H.Pipes;
 
 /// <summary>
-/// 
+/// A named pipe server.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
+public interface IPipeServer : IPipeConnection
+{
+    #region Properties
+
+    /// <summary>
+    /// Pipe name.
+    /// </summary>
+    string PipeName { get; }
+
+    /// <summary>
+    /// Creates a pipe stream for the specified pipe name.
+    /// </summary>
+    Func<string, NamedPipeServerStream>? CreatePipeStreamFunc { get; set; }
+
+    /// <summary>
+    /// Action invoked for created pipe streams.
+    /// </summary>
+    Action<NamedPipeServerStream>? PipeStreamInitializeAction { get; set; }
+
+    /// <summary>
+    /// Is started.
+    /// </summary>
+    bool IsStarted { get; }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a client connects to the server.
+    /// </summary>
+    event EventHandler<ConnectionEventArgs>? ClientConnected;
+
+    /// <summary>
+    /// Invoked whenever a client disconnects from the server.
+    /// </summary>
+    event EventHandler<ConnectionEventArgs>? ClientDisconnected;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Begins listening for client connections in a separate background thread.
+    /// This method waits when pipe will be created(or throws exception).
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IOException"></exception>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Closes all open client connections and stops listening for new ones.
+    /// </summary>
+    Task StopAsync(CancellationToken _ = default);
+
+    #endregion
+}
+
+/// <summary>
+/// A typed named pipe server.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
 public interface IPipeServer<T> : IPipeConnection<T>
 {
     #region Properties
 
     /// <summary>
-    /// Name of pipe
+    /// Pipe name.
     /// </summary>
     string PipeName { get; }
 
     /// <summary>
-    /// CreatePipeStreamFunc
+    /// Creates a pipe stream for the specified pipe name.
     /// </summary>
     Func<string, NamedPipeServerStream>? CreatePipeStreamFunc { get; set; }
 
     /// <summary>
-    /// PipeStreamInitializeAction
+    /// Action invoked for created pipe streams.
     /// </summary>
     Action<NamedPipeServerStream>? PipeStreamInitializeAction { get; set; }
 
     /// <summary>
-    /// IsStarted
+    /// Is started.
     /// </summary>
     bool IsStarted { get; }
 

--- a/src/libs/H.Pipes/PipeClient.cs
+++ b/src/libs/H.Pipes/PipeClient.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using System.Text;
 using H.Formatters;
 using H.Pipes.Args;
@@ -9,8 +9,7 @@ namespace H.Pipes;
 /// <summary>
 /// Wraps a <see cref="NamedPipeClientStream"/>.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class PipeClient<T> : IPipeClient<T>
+public class PipeClient : IPipeClient
 {
     #region Fields
 
@@ -37,13 +36,10 @@ public sealed class PipeClient<T> : IPipeClient<T>
     }
 
     /// <inheritdoc/>
-    public IFormatter Formatter { get; }
-    
-    /// <inheritdoc/>
     public Func<string, string, NamedPipeClientStream>? CreatePipeStreamFunc { get; set; }
-    
+
     /// <summary>
-    /// If set, used instead of CreatePipeStreamFunc for connections
+    /// If set, used instead of CreatePipeStreamFunc for connections.
     /// </summary>
     public Func<string, string, NamedPipeClientStream>? CreatePipeStreamForConnectionFunc { get; set; }
 
@@ -54,7 +50,7 @@ public sealed class PipeClient<T> : IPipeClient<T>
     public string ServerName { get; }
 
     /// <inheritdoc/>
-    public PipeConnection<T>? Connection { get; private set; }
+    public PipeConnection? Connection { get; private set; }
 
     private System.Timers.Timer ReconnectionTimer { get; }
 
@@ -65,39 +61,55 @@ public sealed class PipeClient<T> : IPipeClient<T>
     /// <summary>
     /// Invoked whenever a message is received from the server.
     /// </summary>
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    public event EventHandler<ConnectionMessageEventArgs>? MessageReceived;
 
     /// <summary>
     /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+    public event EventHandler<ConnectionEventArgs>? Disconnected;
 
     /// <summary>
     /// Invoked after each the client connect to the server (include reconnects).
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Connected;
+    public event EventHandler<ConnectionEventArgs>? Connected;
 
     /// <summary>
     /// Invoked whenever an exception is thrown during a read or write operation on the named pipe.
     /// </summary>
     public event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
 
-    private void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs args)
     {
         MessageReceived?.Invoke(this, args);
     }
 
-    private void OnDisconnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="Disconnected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnDisconnected(ConnectionEventArgs args)
     {
         Disconnected?.Invoke(this, args);
     }
 
-    private void OnConnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="Connected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnConnected(ConnectionEventArgs args)
     {
         Connected?.Invoke(this, args);
     }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Invokes <see cref="ExceptionOccurred"/>.
+    /// </summary>
+    /// <param name="exception"></param>
+    protected virtual void OnExceptionOccurred(Exception exception)
     {
         ExceptionOccurred?.Invoke(this, new ExceptionEventArgs(exception));
     }
@@ -107,14 +119,13 @@ public sealed class PipeClient<T> : IPipeClient<T>
     #region Constructors
 
     /// <summary>
-    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
-    /// Default reconnection interval - <see langword="100 ms"/>
+    /// Constructs a new <see cref="PipeClient"/> to connect to the <see cref="PipeServer"/> specified by <paramref name="pipeName"/>. <br/>
+    /// Default reconnection interval - <see langword="100 ms"/>.
     /// </summary>
-    /// <param name="pipeName">Name of the server's pipe</param>
-    /// <param name="serverName">the Name of the server, default is  local machine</param>
-    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/></param>
-    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/></param>
-    public PipeClient(string pipeName, IFormatter formatter, string serverName = ".", TimeSpan? reconnectionInterval = default)
+    /// <param name="pipeName">Name of the server's pipe.</param>
+    /// <param name="serverName">The name of the server, default is local machine.</param>
+    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/>.</param>
+    public PipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default)
     {
         PipeName = pipeName;
         ServerName = serverName;
@@ -145,26 +156,8 @@ public sealed class PipeClient<T> : IPipeClient<T>
                 OnExceptionOccurred(exception);
             }
         };
+    }
 
-        Formatter = formatter;
-    }
-    
-    /// <summary>
-    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
-    /// Default reconnection interval - <see langword="100 ms"/>
-    /// </summary>
-    /// <param name="pipeName">Name of the server's pipe</param>
-    /// <param name="serverName">the Name of the server, default is  local machine</param>
-    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/></param>
-#if NET6_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-#endif
-    public PipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default)
-        : this(pipeName, new DefaultFormatter(), serverName, reconnectionInterval)
-    {
-    }
-    
     #endregion
 
     #region Public methods
@@ -196,7 +189,7 @@ public sealed class PipeClient<T> : IPipeClient<T>
 
             var connectionPipeName = await GetConnectionPipeName(cancellationToken).ConfigureAwait(false);
 
-            // Connect to the actual data pipe
+            // Connect to the actual data pipe.
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var dataPipe = await PipeClientFactory.CreateAndConnectAsync(
                 pipeName: connectionPipeName,
@@ -206,25 +199,12 @@ public sealed class PipeClient<T> : IPipeClient<T>
 #pragma warning restore CA2000 // Dispose objects before losing scope
                     .ConfigureAwait(false);
 
-            Connection = new PipeConnection<T>(dataPipe, connectionPipeName, Formatter, ServerName);
-            Connection.Disconnected += async (_, args) =>
-            {
-                try
-                {
-                    await DisconnectInternalAsync().ConfigureAwait(false);
-                }
-                catch(Exception exception)
-                {
-                    OnExceptionOccurred(exception);
-                }
+            var connection = CreateConnection(dataPipe, connectionPipeName, ServerName);
+            Connection = connection;
+            ConfigureConnection(connection);
+            connection.Start();
 
-                OnDisconnected(args);
-            };
-            Connection.MessageReceived += (_, args) => OnMessageReceived(args);
-            Connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
-            Connection.Start();
-
-            OnConnected(new ConnectionEventArgs<T>(Connection));
+            OnConnected(new ConnectionEventArgs(connection));
         }
         catch (Exception)
         {
@@ -239,7 +219,7 @@ public sealed class PipeClient<T> : IPipeClient<T>
     }
 
     /// <summary>
-    /// Disconnects from server
+    /// Disconnects from server.
     /// </summary>
     /// <param name="_"></param>
     /// <returns></returns>
@@ -250,26 +230,14 @@ public sealed class PipeClient<T> : IPipeClient<T>
         await DisconnectInternalAsync().ConfigureAwait(false);
     }
 
-    private async Task DisconnectInternalAsync()
-    {
-        if (Connection == null)
-        {
-            return;
-        }
-
-        await Connection.DisposeAsync().ConfigureAwait(false);
-
-        Connection = null;
-    }
-
     /// <summary>
     /// Sends a message to the server over a named pipe. <br/>
-    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred
+    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred.
     /// </summary>
     /// <param name="value">Message to send to the server.</param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
     {
         if (!IsConnected && AutoReconnect)
         {
@@ -288,21 +256,76 @@ public sealed class PipeClient<T> : IPipeClient<T>
     #region IDisposable
 
     /// <summary>
-    /// Dispose internal resources
+    /// Dispose internal resources.
     /// </summary>
     public async ValueTask DisposeAsync()
     {
         ReconnectionTimer.Dispose();
 
         await DisconnectInternalAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <summary>
+    /// Creates the data connection used by this client.
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="pipeName"></param>
+    /// <param name="serverName"></param>
+    /// <returns></returns>
+    protected virtual PipeConnection CreateConnection(PipeStream stream, string pipeName, string serverName)
+    {
+        return new PipeConnection(stream, pipeName, serverName);
+    }
+
+    /// <summary>
+    /// Subscribes to connection events.
+    /// </summary>
+    /// <param name="connection"></param>
+    protected virtual void ConfigureConnection(PipeConnection connection)
+    {
+        connection = connection ?? throw new ArgumentNullException(nameof(connection));
+
+        connection.Disconnected += async (_, args) =>
+        {
+            try
+            {
+                await DisconnectInternalAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                OnExceptionOccurred(exception);
+            }
+
+            OnDisconnected(args);
+        };
+        connection.MessageReceived += (_, args) => OnMessageReceived(args);
+        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
     }
 
     #endregion
 
     #region Private methods
 
+    private async Task DisconnectInternalAsync()
+    {
+        if (Connection == null)
+        {
+            return;
+        }
+
+        await Connection.DisposeAsync().ConfigureAwait(false);
+
+        Connection = null;
+    }
+
     /// <summary>
-    /// Get the name of the data pipe that should be used from now on by this NamedPipeClient
+    /// Get the name of the data pipe that should be used from now on by this NamedPipeClient.
     /// </summary>
     /// <exception cref="InvalidOperationException"></exception>
     /// <returns></returns>
@@ -326,6 +349,157 @@ public sealed class PipeClient<T> : IPipeClient<T>
             }
 
             return Encoding.UTF8.GetString(bytes);
+        }
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeClientStream"/>.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
+public class PipeClient<T> : PipeClient, IPipeClient<T>
+{
+    #region Properties
+
+    /// <inheritdoc/>
+    public IFormatter Formatter { get; }
+
+    /// <inheritdoc/>
+    public new PipeConnection<T>? Connection => base.Connection as PipeConnection<T>;
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a message is received from the server.
+    /// </summary>
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <summary>
+    /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
+    /// </summary>
+    public new event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+
+    /// <summary>
+    /// Invoked after each the client connect to the server (include reconnects).
+    /// </summary>
+    public new event EventHandler<ConnectionEventArgs<T>>? Connected;
+
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    {
+        MessageReceived?.Invoke(this, args);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDisconnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnDisconnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            Disconnected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnConnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnConnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            Connected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
+    /// Default reconnection interval - <see langword="100 ms"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the server's pipe.</param>
+    /// <param name="serverName">The name of the server, default is local machine.</param>
+    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/>.</param>
+    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/>.</param>
+    public PipeClient(string pipeName, IFormatter formatter, string serverName = ".", TimeSpan? reconnectionInterval = default)
+        : base(pipeName, serverName, reconnectionInterval)
+    {
+        Formatter = formatter;
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
+    /// Default reconnection interval - <see langword="100 ms"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the server's pipe.</param>
+    /// <param name="serverName">The name of the server, default is local machine.</param>
+    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/>.</param>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+    public PipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default)
+        : this(pipeName, new DefaultFormatter(), serverName, reconnectionInterval)
+    {
+    }
+
+    #endregion
+
+    #region Public methods
+
+    /// <summary>
+    /// Sends a message to the server over a named pipe. <br/>
+    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred.
+    /// </summary>
+    /// <param name="value">Message to send to the server.</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    {
+        if (!IsConnected && AutoReconnect)
+        {
+            await ConnectAsync(cancellationToken).ConfigureAwait(false);
+        }
+        if (Connection == null)
+        {
+            throw new InvalidOperationException("Client is not connected");
+        }
+
+        await Connection.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <inheritdoc/>
+    protected override PipeConnection CreateConnection(PipeStream stream, string pipeName, string serverName)
+    {
+        return new PipeConnection<T>(stream, pipeName, Formatter, serverName);
+    }
+
+    /// <inheritdoc/>
+    protected override void ConfigureConnection(PipeConnection connection)
+    {
+        base.ConfigureConnection(connection);
+
+        if (connection is PipeConnection<T> typedConnection)
+        {
+            typedConnection.MessageReceived += (_, args) => OnMessageReceived(args);
         }
     }
 

--- a/src/libs/H.Pipes/PipeConnection.cs
+++ b/src/libs/H.Pipes/PipeConnection.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using H.Formatters;
 using H.Pipes.Args;
 using H.Pipes.IO;
@@ -7,10 +7,9 @@ using H.Pipes.Utilities;
 namespace H.Pipes;
 
 /// <summary>
-/// Represents a connection between a named pipe client and server.
+/// Represents a raw byte connection between a named pipe client and server.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class PipeConnection<T> : IAsyncDisposable
+public class PipeConnection : IPipeConnection
 {
     #region Properties
 
@@ -39,11 +38,6 @@ public sealed class PipeConnection<T> : IAsyncDisposable
     /// </summary>
     public PipeStream PipeStream { get; }
 
-    /// <summary>
-    /// Used formatter.
-    /// </summary>
-    public IFormatter Formatter { get; set; }
-
     private PipeStreamWrapper PipeStreamWrapper { get; }
     private TaskWorker? ReadWorker { get; set; }
 
@@ -54,43 +48,63 @@ public sealed class PipeConnection<T> : IAsyncDisposable
     /// <summary>
     /// Invoked when the named pipe connection terminates.
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+    public event EventHandler<ConnectionEventArgs>? Disconnected;
 
     /// <summary>
     /// Invoked whenever a message is received from the other end of the pipe.
     /// </summary>
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    public event EventHandler<ConnectionMessageEventArgs>? MessageReceived;
 
     /// <summary>
     /// Invoked when an exception is thrown during any read/write operation over the named pipe.
     /// </summary>
-    public event EventHandler<ConnectionExceptionEventArgs<T>>? ExceptionOccurred;
+    public event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
 
-    private void OnDisconnected()
+    /// <summary>
+    /// Invokes <see cref="Disconnected"/>.
+    /// </summary>
+    protected virtual void OnDisconnected()
     {
-        Disconnected?.Invoke(this, new ConnectionEventArgs<T>(this));
+        Disconnected?.Invoke(this, new ConnectionEventArgs(this));
     }
 
-    private void OnMessageReceived(T? message)
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected virtual Task OnMessageReceivedAsync(byte[]? message, CancellationToken cancellationToken = default)
     {
-        MessageReceived?.Invoke(this, new ConnectionMessageEventArgs<T?>(this, message));
+        MessageReceived?.Invoke(this, new ConnectionMessageEventArgs(this, message));
+
+        return Task.CompletedTask;
     }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Invokes <see cref="ExceptionOccurred"/>.
+    /// </summary>
+    /// <param name="exception"></param>
+    protected virtual void OnExceptionOccurred(Exception exception)
     {
-        ExceptionOccurred?.Invoke(this, new ConnectionExceptionEventArgs<T>(this, exception));
+        ExceptionOccurred?.Invoke(this, new ExceptionEventArgs(exception));
     }
 
     #endregion
 
     #region Constructors
 
-    internal PipeConnection(PipeStream stream, string pipeName, IFormatter formatter, string serverName = "")
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PipeConnection"/> class.
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="pipeName"></param>
+    /// <param name="serverName"></param>
+    public PipeConnection(PipeStream stream, string pipeName, string serverName = "")
     {
         PipeName = pipeName;
         PipeStream = stream;
         PipeStreamWrapper = new PipeStreamWrapper(stream);
-        Formatter = formatter;
         ServerName = serverName;
     }
 
@@ -115,7 +129,7 @@ public sealed class PipeConnection<T> : IAsyncDisposable
             {
                 return;
             }
-            
+
             while (!cancellationToken.IsCancellationRequested && IsConnected)
             {
                 try
@@ -126,11 +140,7 @@ public sealed class PipeConnection<T> : IAsyncDisposable
                         break;
                     }
 
-                    var obj = Formatter is IAsyncFormatter asyncFormatter
-                        ? await asyncFormatter.DeserializeAsync<T>(bytes, cancellationToken).ConfigureAwait(false)
-                        : Formatter.Deserialize<T>(bytes);
-
-                    OnMessageReceived(obj);
+                    await OnMessageReceivedAsync(bytes, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -148,26 +158,22 @@ public sealed class PipeConnection<T> : IAsyncDisposable
     }
 
     /// <summary>
-    /// Writes the specified <paramref name="value"/> and waits other end reading
+    /// Writes the specified <paramref name="value"/> and waits other end reading.
     /// </summary>
     /// <param name="value"></param>
     /// <param name="cancellationToken"></param>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
     {
         if (!IsConnected || !PipeStreamWrapper.CanWrite)
         {
             throw new InvalidOperationException("Client is not connected");
         }
 
-        var bytes = Formatter is IAsyncFormatter asyncFormatter
-            ? await asyncFormatter.SerializeAsync(value, cancellationToken).ConfigureAwait(false)
-            : Formatter.Serialize(value);
-
-        await PipeStreamWrapper.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+        await PipeStreamWrapper.WriteAsync(value, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Dispose internal resources
+    /// Dispose internal resources.
     /// </summary>
     public async Task StopAsync()
     {
@@ -207,11 +213,103 @@ public sealed class PipeConnection<T> : IAsyncDisposable
     #region IDisposable
 
     /// <summary>
-    /// Dispose internal resources
+    /// Dispose internal resources.
     /// </summary>
     public async ValueTask DisposeAsync()
     {
         await StopAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Represents a typed connection between a named pipe client and server.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
+public class PipeConnection<T> : PipeConnection, IPipeConnection<T>
+{
+    #region Properties
+
+    /// <summary>
+    /// Used formatter.
+    /// </summary>
+    public IFormatter Formatter { get; set; }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Invoked when the named pipe connection terminates.
+    /// </summary>
+    public new event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+
+    /// <summary>
+    /// Invoked whenever a message is received from the other end of the pipe.
+    /// </summary>
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <summary>
+    /// Invoked when an exception is thrown during any read/write operation over the named pipe.
+    /// </summary>
+    public new event EventHandler<ConnectionExceptionEventArgs<T>>? ExceptionOccurred;
+
+    /// <inheritdoc />
+    protected override void OnDisconnected()
+    {
+        base.OnDisconnected();
+
+        Disconnected?.Invoke(this, new ConnectionEventArgs<T>(this));
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnMessageReceivedAsync(byte[]? message, CancellationToken cancellationToken = default)
+    {
+        var obj = Formatter is IAsyncFormatter asyncFormatter
+            ? await asyncFormatter.DeserializeAsync<T>(message, cancellationToken).ConfigureAwait(false)
+            : Formatter.Deserialize<T>(message);
+
+        MessageReceived?.Invoke(this, new ConnectionMessageEventArgs<T?>(this, obj));
+
+        await base.OnMessageReceivedAsync(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected override void OnExceptionOccurred(Exception exception)
+    {
+        base.OnExceptionOccurred(exception);
+
+        ExceptionOccurred?.Invoke(this, new ConnectionExceptionEventArgs<T>(this, exception));
+    }
+
+    #endregion
+
+    #region Constructors
+
+    internal PipeConnection(PipeStream stream, string pipeName, IFormatter formatter, string serverName = "") : base(stream, pipeName, serverName)
+    {
+        Formatter = formatter;
+    }
+
+    #endregion
+
+    #region Public methods
+
+    /// <summary>
+    /// Writes the specified <paramref name="value"/> and waits other end reading.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="cancellationToken"></param>
+    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    {
+        var bytes = Formatter is IAsyncFormatter asyncFormatter
+            ? await asyncFormatter.SerializeAsync(value, cancellationToken).ConfigureAwait(false)
+            : Formatter.Serialize(value);
+
+        await WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
     }
 
     #endregion

--- a/src/libs/H.Pipes/PipeServer.cs
+++ b/src/libs/H.Pipes/PipeServer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using System.Text;
 using H.Formatters;
 using H.Pipes.Args;
@@ -11,8 +11,7 @@ namespace H.Pipes;
 /// <summary>
 /// Wraps a <see cref="NamedPipeServerStream"/> and provides multiple simultaneous client connection handling.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class PipeServer<T> : IPipeServer<T>
+public class PipeServer : IPipeServer
 {
     #region Properties
 
@@ -23,30 +22,27 @@ public sealed class PipeServer<T> : IPipeServer<T>
     public Func<string, NamedPipeServerStream>? CreatePipeStreamFunc { get; set; }
 
     /// <summary>
-    /// If set, used instead of CreatePipeStreamFunc for connections
+    /// If set, used instead of CreatePipeStreamFunc for connections.
     /// </summary>
     public Func<string, NamedPipeServerStream>? CreatePipeStreamForConnectionFunc { get; set; }
 
     /// <inheritdoc />
     public Action<NamedPipeServerStream>? PipeStreamInitializeAction { get; set; }
 
-    /// <inheritdoc />
-    public IFormatter Formatter { get; set; }
-
     /// <summary>
-    /// Indicates whether to wait for a name to be released when calling StartAsync()
+    /// Indicates whether to wait for a name to be released when calling StartAsync().
     /// </summary>
     public bool WaitFreePipe { get; set; }
 
     /// <summary>
-    /// All connections(include disconnected clients)
+    /// All connections(include disconnected clients).
     /// </summary>
-    private List<PipeConnection<T>> Connections { get; } = new();
+    private List<PipeConnection> Connections { get; } = new();
 
     /// <summary>
-    /// Connected clients
+    /// Connected clients.
     /// </summary>
-    public IReadOnlyCollection<PipeConnection<T>> ConnectedClients => Connections
+    public IReadOnlyCollection<PipeConnection> ConnectedClients => Connections
         .Where(connection => connection.IsConnected)
         .ToList();
 
@@ -62,33 +58,49 @@ public sealed class PipeServer<T> : IPipeServer<T>
     #region Events
 
     /// <inheritdoc />
-    public event EventHandler<ConnectionEventArgs<T>>? ClientConnected;
+    public event EventHandler<ConnectionEventArgs>? ClientConnected;
 
     /// <inheritdoc />
-    public event EventHandler<ConnectionEventArgs<T>>? ClientDisconnected;
+    public event EventHandler<ConnectionEventArgs>? ClientDisconnected;
 
     /// <inheritdoc />
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    public event EventHandler<ConnectionMessageEventArgs>? MessageReceived;
 
     /// <inheritdoc />
     public event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
 
-    private void OnClientConnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="ClientConnected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnClientConnected(ConnectionEventArgs args)
     {
         ClientConnected?.Invoke(this, args);
     }
 
-    private void OnClientDisconnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="ClientDisconnected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnClientDisconnected(ConnectionEventArgs args)
     {
         ClientDisconnected?.Invoke(this, args);
     }
 
-    private void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs args)
     {
         MessageReceived?.Invoke(this, args);
     }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Invokes <see cref="ExceptionOccurred"/>.
+    /// </summary>
+    /// <param name="exception"></param>
+    protected virtual void OnExceptionOccurred(Exception exception)
     {
         ExceptionOccurred?.Invoke(this, new ExceptionEventArgs(exception));
     }
@@ -100,24 +112,10 @@ public sealed class PipeServer<T> : IPipeServer<T>
     /// <summary>
     /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
     /// </summary>
-    /// <param name="pipeName">Name of the pipe to listen on</param>
-    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/></param>
-    public PipeServer(string pipeName, IFormatter formatter)
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+    public PipeServer(string pipeName)
     {
         PipeName = pipeName;
-        Formatter = formatter;
-    }
-    
-    /// <summary>
-    /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
-    /// </summary>
-    /// <param name="pipeName">Name of the pipe to listen on</param>
-#if NET6_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-#endif
-    public PipeServer(string pipeName) : this(pipeName, new DefaultFormatter())
-    {
     }
 
     #endregion
@@ -145,7 +143,7 @@ public sealed class PipeServer<T> : IPipeServer<T>
                 {
                     var connectionPipeName = $"{PipeName}_{Guid.NewGuid()}";
 
-                    // Send the client the name of the data pipe to use
+                    // Send the client the name of the data pipe to use.
                     try
                     {
 #if NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER
@@ -188,7 +186,7 @@ public sealed class PipeServer<T> : IPipeServer<T>
                         break;
                     }
 
-                    // Wait for the client to connect to the data pipe
+                    // Wait for the client to connect to the data pipe.
                     var connectionStream = (CreatePipeStreamForConnectionFunc ?? CreatePipeStreamFunc)?
                         .Invoke(connectionPipeName) ?? PipeServerFactory.Create(connectionPipeName);
 
@@ -211,16 +209,14 @@ public sealed class PipeServer<T> : IPipeServer<T>
                         throw;
                     }
 
-                    // Add the client's connection to the list of connections
-                    var connection = new PipeConnection<T>(connectionStream, connectionPipeName, Formatter);
-                    connection.MessageReceived += (_, args) => OnMessageReceived(args);
-                    connection.Disconnected += (_, args) => OnClientDisconnected(args);
-                    connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+                    // Add the client's connection to the list of connections.
+                    var connection = CreateConnection(connectionStream, connectionPipeName);
+                    ConfigureConnection(connection);
                     connection.Start();
 
                     Connections.Add(connection);
 
-                    OnClientConnected(new ConnectionEventArgs<T>(connection));
+                    OnClientConnected(new ConnectionEventArgs(connection));
                 }
                 catch (OperationCanceledException)
                 {
@@ -257,7 +253,7 @@ public sealed class PipeServer<T> : IPipeServer<T>
     /// </summary>
     /// <param name="value"></param>
     /// <param name="cancellationToken"></param>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
     {
         await WriteAsync(value, predicate: null, cancellationToken).ConfigureAwait(false);
     }
@@ -268,7 +264,7 @@ public sealed class PipeServer<T> : IPipeServer<T>
     /// <param name="value"></param>
     /// <param name="predicate"></param>
     /// <param name="cancellationToken"></param>
-    public async Task WriteAsync(T value, Predicate<PipeConnection<T>>? predicate, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, Predicate<PipeConnection>? predicate, CancellationToken cancellationToken = default)
     {
         var tasks = Connections
             .Where(connection => connection.IsConnected && (predicate == null || predicate(connection)))
@@ -284,7 +280,7 @@ public sealed class PipeServer<T> : IPipeServer<T>
     /// <param name="value"></param>
     /// <param name="pipeName"></param>
     /// <param name="cancellationToken"></param>
-    public async Task WriteAsync(T value, string pipeName, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, string pipeName, CancellationToken cancellationToken = default)
     {
         await WriteAsync(value, connection => connection.PipeName == pipeName, cancellationToken).ConfigureAwait(false);
     }
@@ -323,6 +319,194 @@ public sealed class PipeServer<T> : IPipeServer<T>
         _isDisposed = true;
 
         await StopAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <summary>
+    /// Creates a connection for a connected client stream.
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="pipeName"></param>
+    /// <returns></returns>
+    protected virtual PipeConnection CreateConnection(PipeStream stream, string pipeName)
+    {
+        return new PipeConnection(stream, pipeName);
+    }
+
+    /// <summary>
+    /// Subscribes to connection events.
+    /// </summary>
+    /// <param name="connection"></param>
+    protected virtual void ConfigureConnection(PipeConnection connection)
+    {
+        connection = connection ?? throw new ArgumentNullException(nameof(connection));
+
+        connection.MessageReceived += (_, args) => OnMessageReceived(args);
+        connection.Disconnected += (_, args) => OnClientDisconnected(args);
+        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeServerStream"/> and provides multiple simultaneous client connection handling.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
+public class PipeServer<T> : PipeServer, IPipeServer<T>
+{
+    #region Properties
+
+    /// <inheritdoc />
+    public IFormatter Formatter { get; set; }
+
+    /// <summary>
+    /// Connected clients.
+    /// </summary>
+    public new IReadOnlyCollection<PipeConnection<T>> ConnectedClients => base.ConnectedClients
+        .OfType<PipeConnection<T>>()
+        .ToList();
+
+    #endregion
+
+    #region Events
+
+    /// <inheritdoc />
+    public new event EventHandler<ConnectionEventArgs<T>>? ClientConnected;
+
+    /// <inheritdoc />
+    public new event EventHandler<ConnectionEventArgs<T>>? ClientDisconnected;
+
+    /// <inheritdoc />
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    {
+        MessageReceived?.Invoke(this, args);
+    }
+
+    /// <inheritdoc />
+    protected override void OnClientConnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnClientConnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            ClientConnected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnClientDisconnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnClientDisconnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            ClientDisconnected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/>.</param>
+    public PipeServer(string pipeName, IFormatter formatter) : base(pipeName)
+    {
+        Formatter = formatter;
+    }
+
+    /// <summary>
+    /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+    public PipeServer(string pipeName) : this(pipeName, new DefaultFormatter())
+    {
+    }
+
+    #endregion
+
+    #region Public methods
+
+    /// <summary>
+    /// Sends a message to all connected clients asynchronously.
+    /// This method returns immediately, possibly before the message has been sent to all clients.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="cancellationToken"></param>
+    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    {
+        await WriteAsync(value, predicate: null, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends a message to all connected clients asynchronously.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="predicate"></param>
+    /// <param name="cancellationToken"></param>
+    public async Task WriteAsync(T value, Predicate<PipeConnection<T>>? predicate, CancellationToken cancellationToken = default)
+    {
+        var tasks = ConnectedClients
+            .Where(connection => predicate == null || predicate(connection))
+            .Select(connection => connection.WriteAsync(value, cancellationToken))
+            .ToList();
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends a message to the given client by pipe name.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="pipeName"></param>
+    /// <param name="cancellationToken"></param>
+    public async Task WriteAsync(T value, string pipeName, CancellationToken cancellationToken = default)
+    {
+        await WriteAsync(value, connection => connection.PipeName == pipeName, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <inheritdoc />
+    protected override PipeConnection CreateConnection(PipeStream stream, string pipeName)
+    {
+        return new PipeConnection<T>(stream, pipeName, Formatter);
+    }
+
+    /// <inheritdoc />
+    protected override void ConfigureConnection(PipeConnection connection)
+    {
+        base.ConfigureConnection(connection);
+
+        if (connection is PipeConnection<T> typedConnection)
+        {
+            typedConnection.MessageReceived += (_, args) => OnMessageReceived(args);
+        }
     }
 
     #endregion

--- a/src/libs/H.Pipes/SingleConnectionPipeClient.cs
+++ b/src/libs/H.Pipes/SingleConnectionPipeClient.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using H.Formatters;
 using H.Pipes.Args;
 using H.Pipes.Factories;
@@ -8,8 +8,7 @@ namespace H.Pipes;
 /// <summary>
 /// Wraps a <see cref="NamedPipeClientStream"/>.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
+public class SingleConnectionPipeClient : IPipeClient
 {
     #region Fields
 
@@ -36,9 +35,6 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
     }
 
     /// <inheritdoc/>
-    public IFormatter Formatter { get; }
-    
-    /// <inheritdoc/>
     public Func<string, string, NamedPipeClientStream>? CreatePipeStreamFunc { get; set; }
 
     /// <inheritdoc/>
@@ -48,7 +44,7 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
     public string ServerName { get; }
 
     /// <inheritdoc/>
-    public PipeConnection<T>? Connection { get; private set; }
+    public PipeConnection? Connection { get; private set; }
 
     private System.Timers.Timer ReconnectionTimer { get; }
 
@@ -59,39 +55,55 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
     /// <summary>
     /// Invoked whenever a message is received from the server.
     /// </summary>
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    public event EventHandler<ConnectionMessageEventArgs>? MessageReceived;
 
     /// <summary>
     /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+    public event EventHandler<ConnectionEventArgs>? Disconnected;
 
     /// <summary>
     /// Invoked after each the client connect to the server (include reconnects).
     /// </summary>
-    public event EventHandler<ConnectionEventArgs<T>>? Connected;
+    public event EventHandler<ConnectionEventArgs>? Connected;
 
     /// <summary>
     /// Invoked whenever an exception is thrown during a read or write operation on the named pipe.
     /// </summary>
     public event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
 
-    private void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs args)
     {
         MessageReceived?.Invoke(this, args);
     }
 
-    private void OnDisconnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="Disconnected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnDisconnected(ConnectionEventArgs args)
     {
         Disconnected?.Invoke(this, args);
     }
 
-    private void OnConnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="Connected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnConnected(ConnectionEventArgs args)
     {
         Connected?.Invoke(this, args);
     }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Invokes <see cref="ExceptionOccurred"/>.
+    /// </summary>
+    /// <param name="exception"></param>
+    protected virtual void OnExceptionOccurred(Exception exception)
     {
         ExceptionOccurred?.Invoke(this, new ExceptionEventArgs(exception));
     }
@@ -101,14 +113,13 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
     #region Constructors
 
     /// <summary>
-    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
-    /// Default reconnection interval - <see langword="100 ms"/>
+    /// Constructs a new <see cref="SingleConnectionPipeClient"/> to connect to the <see cref="SingleConnectionPipeServer"/> specified by <paramref name="pipeName"/>. <br/>
+    /// Default reconnection interval - <see langword="100 ms"/>.
     /// </summary>
-    /// <param name="pipeName">Name of the server's pipe</param>
-    /// <param name="serverName">the Name of the server, default is  local machine</param>
-    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/></param>
-    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/></param>
-    public SingleConnectionPipeClient(string pipeName, IFormatter formatter, string serverName = ".", TimeSpan? reconnectionInterval = default)
+    /// <param name="pipeName">Name of the server's pipe.</param>
+    /// <param name="serverName">The name of the server, default is local machine.</param>
+    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/>.</param>
+    public SingleConnectionPipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default)
     {
         PipeName = pipeName;
         ServerName = serverName;
@@ -140,24 +151,6 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
                 OnExceptionOccurred(exception);
             }
         };
-
-        Formatter = formatter;
-    }
-    
-    /// <summary>
-    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
-    /// Default reconnection interval - <see langword="100 ms"/>
-    /// </summary>
-    /// <param name="pipeName">Name of the server's pipe</param>
-    /// <param name="serverName">the Name of the server, default is  local machine</param>
-    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/></param>
-#if NET6_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-#endif
-    public SingleConnectionPipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default)
-        : this(pipeName, new DefaultFormatter(), serverName, reconnectionInterval)
-    {
     }
 
     #endregion
@@ -186,25 +179,12 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
 #pragma warning restore CA2000 // Dispose objects before losing scope
                     .ConfigureAwait(false);
 
-            Connection = new PipeConnection<T>(dataPipe, PipeName, Formatter, ServerName);
-            Connection.Disconnected += async (_, args) =>
-            {
-                try
-                {
-                    await DisconnectInternalAsync().ConfigureAwait(false);
-                }
-                catch (Exception exception)
-                {
-                    OnExceptionOccurred(exception);
-                }
+            var connection = CreateConnection(dataPipe, PipeName, ServerName);
+            Connection = connection;
+            ConfigureConnection(connection);
+            connection.Start();
 
-                OnDisconnected(args);
-            };
-            Connection.MessageReceived += (_, args) => OnMessageReceived(args);
-            Connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
-            Connection.Start();
-
-            OnConnected(new ConnectionEventArgs<T>(Connection));
+            OnConnected(new ConnectionEventArgs(connection));
         }
         catch (Exception)
         {
@@ -226,26 +206,14 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
         await DisconnectInternalAsync().ConfigureAwait(false);
     }
 
-    private async Task DisconnectInternalAsync()
-    {
-        if (Connection == null)
-        {
-            return;
-        }
-
-        await Connection.StopAsync().ConfigureAwait(false);
-
-        Connection = null;
-    }
-
     /// <summary>
     /// Sends a message to the server over a named pipe. <br/>
-    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred
+    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred.
     /// </summary>
     /// <param name="value">Message to send to the server.</param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
     {
         if (!IsConnected && AutoReconnect && !IsConnecting)
         {
@@ -255,7 +223,7 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
         {
             await Task.Delay(TimeSpan.FromMilliseconds(1), cancellationToken).ConfigureAwait(false);
         }
-        if (Connection == null) // nullable detection system is not very smart
+        if (Connection == null)
         {
             throw new InvalidOperationException("Client is not connected");
         }
@@ -273,6 +241,220 @@ public sealed class SingleConnectionPipeClient<T> : IPipeClient<T>
         ReconnectionTimer.Dispose();
 
         await DisconnectInternalAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <summary>
+    /// Creates the data connection used by this client.
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="pipeName"></param>
+    /// <param name="serverName"></param>
+    /// <returns></returns>
+    protected virtual PipeConnection CreateConnection(PipeStream stream, string pipeName, string serverName)
+    {
+        return new PipeConnection(stream, pipeName, serverName);
+    }
+
+    /// <summary>
+    /// Subscribes to connection events.
+    /// </summary>
+    /// <param name="connection"></param>
+    protected virtual void ConfigureConnection(PipeConnection connection)
+    {
+        connection = connection ?? throw new ArgumentNullException(nameof(connection));
+
+        connection.Disconnected += async (_, args) =>
+        {
+            try
+            {
+                await DisconnectInternalAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                OnExceptionOccurred(exception);
+            }
+
+            OnDisconnected(args);
+        };
+        connection.MessageReceived += (_, args) => OnMessageReceived(args);
+        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+    }
+
+    #endregion
+
+    #region Private methods
+
+    private async Task DisconnectInternalAsync()
+    {
+        if (Connection == null)
+        {
+            return;
+        }
+
+        await Connection.StopAsync().ConfigureAwait(false);
+
+        Connection = null;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeClientStream"/>.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
+public class SingleConnectionPipeClient<T> : SingleConnectionPipeClient, IPipeClient<T>
+{
+    #region Properties
+
+    /// <inheritdoc/>
+    public IFormatter Formatter { get; }
+
+    /// <inheritdoc/>
+    public new PipeConnection<T>? Connection => base.Connection as PipeConnection<T>;
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Invoked whenever a message is received from the server.
+    /// </summary>
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <summary>
+    /// Invoked when the client disconnects from the server (e.g., the pipe is closed or broken).
+    /// </summary>
+    public new event EventHandler<ConnectionEventArgs<T>>? Disconnected;
+
+    /// <summary>
+    /// Invoked after each the client connect to the server (include reconnects).
+    /// </summary>
+    public new event EventHandler<ConnectionEventArgs<T>>? Connected;
+
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    {
+        MessageReceived?.Invoke(this, args);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDisconnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnDisconnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            Disconnected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnConnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnConnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            Connected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
+    /// Default reconnection interval - <see langword="100 ms"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the server's pipe.</param>
+    /// <param name="serverName">The name of the server, default is local machine.</param>
+    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/>.</param>
+    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/>.</param>
+    public SingleConnectionPipeClient(string pipeName, IFormatter formatter, string serverName = ".", TimeSpan? reconnectionInterval = default)
+        : base(pipeName, serverName, reconnectionInterval)
+    {
+        Formatter = formatter;
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="PipeClient{T}"/> to connect to the <see cref="PipeServer{T}"/> specified by <paramref name="pipeName"/>. <br/>
+    /// Default reconnection interval - <see langword="100 ms"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the server's pipe.</param>
+    /// <param name="serverName">The name of the server, default is local machine.</param>
+    /// <param name="reconnectionInterval">Default reconnection interval - <see langword="100 ms"/>.</param>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+    public SingleConnectionPipeClient(string pipeName, string serverName = ".", TimeSpan? reconnectionInterval = default)
+        : this(pipeName, new DefaultFormatter(), serverName, reconnectionInterval)
+    {
+    }
+
+    #endregion
+
+    #region Public methods
+
+    /// <summary>
+    /// Sends a message to the server over a named pipe. <br/>
+    /// If client is not connected, <see cref="InvalidOperationException"/> is occurred.
+    /// </summary>
+    /// <param name="value">Message to send to the server.</param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    {
+        if (!IsConnected && AutoReconnect && !IsConnecting)
+        {
+            await ConnectAsync(cancellationToken).ConfigureAwait(false);
+        }
+        while (IsConnecting)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(1), cancellationToken).ConfigureAwait(false);
+        }
+        if (Connection == null)
+        {
+            throw new InvalidOperationException("Client is not connected");
+        }
+
+        await Connection.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <inheritdoc/>
+    protected override PipeConnection CreateConnection(PipeStream stream, string pipeName, string serverName)
+    {
+        return new PipeConnection<T>(stream, pipeName, Formatter, serverName);
+    }
+
+    /// <inheritdoc/>
+    protected override void ConfigureConnection(PipeConnection connection)
+    {
+        base.ConfigureConnection(connection);
+
+        if (connection is PipeConnection<T> typedConnection)
+        {
+            typedConnection.MessageReceived += (_, args) => OnMessageReceived(args);
+        }
     }
 
     #endregion

--- a/src/libs/H.Pipes/SingleConnectionPipeServer.cs
+++ b/src/libs/H.Pipes/SingleConnectionPipeServer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using H.Formatters;
 using H.Pipes.Args;
 using H.Pipes.Factories;
@@ -9,8 +9,7 @@ namespace H.Pipes;
 /// <summary>
 /// Wraps a <see cref="NamedPipeServerStream"/> and optimized for one connection.
 /// </summary>
-/// <typeparam name="T">Reference type to read/write from the named pipe</typeparam>
-public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
+public class SingleConnectionPipeServer : IPipeServer
 {
     #region Properties
 
@@ -23,22 +22,18 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
     /// <inheritdoc/>
     public Action<NamedPipeServerStream>? PipeStreamInitializeAction { get; set; }
 
-    /// <inheritdoc/>
-    public IFormatter Formatter { get; set; }
-
     /// <summary>
-    /// Indicates whether to wait for a name to be released when calling StartAsync()
+    /// Indicates whether to wait for a name to be released when calling StartAsync().
     /// </summary>
     public bool WaitFreePipe { get; set; }
 
     /// <summary>
-    /// Connection
+    /// Connection.
     /// </summary>
-    public PipeConnection<T>? Connection { get; private set; }
+    public PipeConnection? Connection { get; private set; }
 
     /// <inheritdoc/>
     public bool IsStarted => ListenWorker != null && !ListenWorker.Task.IsCompleted && !ListenWorker.Task.IsCanceled && !ListenWorker.Task.IsFaulted;
-
 
     private TaskWorker? ListenWorker { get; set; }
 
@@ -49,33 +44,49 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
     #region Events
 
     /// <inheritdoc/>
-    public event EventHandler<ConnectionEventArgs<T>>? ClientConnected;
+    public event EventHandler<ConnectionEventArgs>? ClientConnected;
 
     /// <inheritdoc/>
-    public event EventHandler<ConnectionEventArgs<T>>? ClientDisconnected;
+    public event EventHandler<ConnectionEventArgs>? ClientDisconnected;
 
     /// <inheritdoc/>
-    public event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+    public event EventHandler<ConnectionMessageEventArgs>? MessageReceived;
 
     /// <inheritdoc/>
     public event EventHandler<ExceptionEventArgs>? ExceptionOccurred;
 
-    private void OnClientConnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="ClientConnected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnClientConnected(ConnectionEventArgs args)
     {
         ClientConnected?.Invoke(this, args);
     }
 
-    private void OnClientDisconnected(ConnectionEventArgs<T> args)
+    /// <summary>
+    /// Invokes <see cref="ClientDisconnected"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnClientDisconnected(ConnectionEventArgs args)
     {
         ClientDisconnected?.Invoke(this, args);
     }
 
-    private void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs args)
     {
         MessageReceived?.Invoke(this, args);
     }
 
-    private void OnExceptionOccurred(Exception exception)
+    /// <summary>
+    /// Invokes <see cref="ExceptionOccurred"/>.
+    /// </summary>
+    /// <param name="exception"></param>
+    protected virtual void OnExceptionOccurred(Exception exception)
     {
         ExceptionOccurred?.Invoke(this, new ExceptionEventArgs(exception));
     }
@@ -87,24 +98,10 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
     /// <summary>
     /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
     /// </summary>
-    /// <param name="pipeName">Name of the pipe to listen on</param>
-    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/></param>
-    public SingleConnectionPipeServer(string pipeName, IFormatter formatter)
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+    public SingleConnectionPipeServer(string pipeName)
     {
         PipeName = pipeName;
-        Formatter = formatter;
-    }
-    
-    /// <summary>
-    /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
-    /// </summary>
-    /// <param name="pipeName">Name of the pipe to listen on</param>
-#if NET6_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
-    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
-#endif
-    public SingleConnectionPipeServer(string pipeName) : this(pipeName, new DefaultFormatter())
-    {
     }
 
     #endregion
@@ -132,7 +129,7 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
                 {
                     if (Connection != null && Connection.IsConnected)
                     {
-                        await Task.Delay(TimeSpan.FromMilliseconds(1), cancellationToken).ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromMilliseconds(1), token).ConfigureAwait(false);
                         continue;
                     }
 
@@ -141,7 +138,7 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
                         await Connection.StopAsync().ConfigureAwait(false);
                     }
 
-                    // Wait for the client to connect to the data pipe
+                    // Wait for the client to connect to the data pipe.
                     var connectionStream = CreatePipeStreamFunc?.Invoke(PipeName) ?? PipeServerFactory.Create(PipeName);
 
                     try
@@ -165,12 +162,10 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
                         throw;
                     }
 
-                    var connection = new PipeConnection<T>(connectionStream, PipeName, Formatter);
+                    var connection = CreateConnection(connectionStream, PipeName);
                     try
                     {
-                        connection.MessageReceived += (_, args) => OnMessageReceived(args);
-                        connection.Disconnected += (_, args) => OnClientDisconnected(args);
-                        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+                        ConfigureConnection(connection);
                         connection.Start();
                     }
                     catch
@@ -182,7 +177,7 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
 
                     Connection = connection;
 
-                    OnClientConnected(new ConnectionEventArgs<T>(connection));
+                    OnClientConnected(new ConnectionEventArgs(connection));
                 }
                 catch (OperationCanceledException)
                 {
@@ -230,7 +225,7 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
     /// </summary>
     /// <param name="value"></param>
     /// <param name="cancellationToken"></param>
-    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    public async Task WriteAsync(byte[] value, CancellationToken cancellationToken = default)
     {
         if (Connection is not { IsConnected: true })
         {
@@ -275,6 +270,169 @@ public sealed class SingleConnectionPipeServer<T> : IPipeServer<T>
         _isDisposed = true;
 
         await StopAsync().ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <summary>
+    /// Creates a connection for a connected client stream.
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="pipeName"></param>
+    /// <returns></returns>
+    protected virtual PipeConnection CreateConnection(PipeStream stream, string pipeName)
+    {
+        return new PipeConnection(stream, pipeName);
+    }
+
+    /// <summary>
+    /// Subscribes to connection events.
+    /// </summary>
+    /// <param name="connection"></param>
+    protected virtual void ConfigureConnection(PipeConnection connection)
+    {
+        connection = connection ?? throw new ArgumentNullException(nameof(connection));
+
+        connection.MessageReceived += (_, args) => OnMessageReceived(args);
+        connection.Disconnected += (_, args) => OnClientDisconnected(args);
+        connection.ExceptionOccurred += (_, args) => OnExceptionOccurred(args.Exception);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Wraps a <see cref="NamedPipeServerStream"/> and optimized for one connection.
+/// </summary>
+/// <typeparam name="T">Reference type to read/write from the named pipe.</typeparam>
+public class SingleConnectionPipeServer<T> : SingleConnectionPipeServer, IPipeServer<T>
+{
+    #region Properties
+
+    /// <inheritdoc/>
+    public IFormatter Formatter { get; set; }
+
+    /// <summary>
+    /// Connection.
+    /// </summary>
+    public new PipeConnection<T>? Connection => base.Connection as PipeConnection<T>;
+
+    #endregion
+
+    #region Events
+
+    /// <inheritdoc/>
+    public new event EventHandler<ConnectionEventArgs<T>>? ClientConnected;
+
+    /// <inheritdoc/>
+    public new event EventHandler<ConnectionEventArgs<T>>? ClientDisconnected;
+
+    /// <inheritdoc/>
+    public new event EventHandler<ConnectionMessageEventArgs<T?>>? MessageReceived;
+
+    /// <summary>
+    /// Invokes <see cref="MessageReceived"/>.
+    /// </summary>
+    /// <param name="args"></param>
+    protected virtual void OnMessageReceived(ConnectionMessageEventArgs<T?> args)
+    {
+        MessageReceived?.Invoke(this, args);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnClientConnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnClientConnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            ClientConnected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnClientDisconnected(ConnectionEventArgs args)
+    {
+        args = args ?? throw new ArgumentNullException(nameof(args));
+
+        base.OnClientDisconnected(args);
+
+        if (args.Connection is PipeConnection<T> connection)
+        {
+            ClientDisconnected?.Invoke(this, new ConnectionEventArgs<T>(connection));
+        }
+    }
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+    /// <param name="formatter">Default formatter - <see cref="DefaultFormatter"/>.</param>
+    public SingleConnectionPipeServer(string pipeName, IFormatter formatter) : base(pipeName)
+    {
+        Formatter = formatter;
+    }
+
+    /// <summary>
+    /// Constructs a new <c>NamedPipeServer</c> object that listens for client connections on the given <paramref name="pipeName"/>.
+    /// </summary>
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+    public SingleConnectionPipeServer(string pipeName) : this(pipeName, new DefaultFormatter())
+    {
+    }
+
+    #endregion
+
+    #region Public methods
+
+    /// <summary>
+    /// Sends a message to all connected clients asynchronously.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="cancellationToken"></param>
+    public async Task WriteAsync(T value, CancellationToken cancellationToken = default)
+    {
+        if (Connection is not { IsConnected: true })
+        {
+            return;
+        }
+
+        await Connection.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Protected methods
+
+    /// <inheritdoc/>
+    protected override PipeConnection CreateConnection(PipeStream stream, string pipeName)
+    {
+        return new PipeConnection<T>(stream, pipeName, Formatter);
+    }
+
+    /// <inheritdoc/>
+    protected override void ConfigureConnection(PipeConnection connection)
+    {
+        base.ConfigureConnection(connection);
+
+        if (connection is PipeConnection<T> typedConnection)
+        {
+            typedConnection.MessageReceived += (_, args) => OnMessageReceived(args);
+        }
     }
 
     #endregion

--- a/src/tests/H.Pipes.Tests/DataTests.cs
+++ b/src/tests/H.Pipes.Tests/DataTests.cs
@@ -161,6 +161,84 @@ public class DataTests
     //{
     //    await BaseTests.BinaryDataSingleTestAsync(1025, 3, new CerasFormatter());
     //}
+
+    [TestMethod]
+    public async Task NonGenericPipeServerRoundTripsRawBytes()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+
+        var pipeName = BaseTests.CreatePipeName("raw");
+        await using var server = new PipeServer(pipeName)
+        {
+            WaitFreePipe = true,
+        };
+        await using var client = new PipeClient(pipeName);
+
+        await RawDataTestAsync(server, client, cancellationTokenSource.Token);
+    }
+
+    [TestMethod]
+    public async Task NonGenericSingleConnectionPipeServerRoundTripsRawBytes()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+
+        var pipeName = BaseTests.CreatePipeName("single-raw");
+        await using var server = new SingleConnectionPipeServer(pipeName)
+        {
+            WaitFreePipe = true,
+        };
+        await using var client = new SingleConnectionPipeClient(pipeName);
+
+        await RawDataTestAsync(server, client, cancellationTokenSource.Token);
+    }
+
+    private static async Task RawDataTestAsync(IPipeServer server, IPipeClient client, CancellationToken cancellationToken)
+    {
+        var values = new[]
+        {
+            Array.Empty<byte>(),
+            new byte[] { 1, 2, 3, 4, 5 },
+        };
+
+        static TaskCompletionSource<byte[]?> CreateCompletionSource()
+        {
+            return new TaskCompletionSource<byte[]?>();
+        }
+
+        var serverCompletionSource = CreateCompletionSource();
+        var clientCompletionSource = CreateCompletionSource();
+
+        using var registration = cancellationToken.Register(() =>
+        {
+            serverCompletionSource.TrySetCanceled();
+            clientCompletionSource.TrySetCanceled();
+        });
+
+        server.MessageReceived += (_, args) => serverCompletionSource.TrySetResult(args.Message);
+        client.MessageReceived += (_, args) => clientCompletionSource.TrySetResult(args.Message);
+        server.ExceptionOccurred += (_, args) => serverCompletionSource.TrySetException(args.Exception);
+        client.ExceptionOccurred += (_, args) => clientCompletionSource.TrySetException(args.Exception);
+
+        await server.StartAsync(cancellationToken).ConfigureAwait(false);
+        await client.ConnectAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var value in values)
+        {
+            serverCompletionSource = CreateCompletionSource();
+
+            await client.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+
+            var serverMessage = await serverCompletionSource.Task.ConfigureAwait(false);
+            serverMessage.Should().Equal(value);
+
+            clientCompletionSource = CreateCompletionSource();
+
+            await server.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+
+            var clientMessage = await clientCompletionSource.Task.ConfigureAwait(false);
+            clientMessage.Should().Equal(value);
+        }
+    }
     
 #if !NET8_0_OR_GREATER
     [TestMethod]


### PR DESCRIPTION
## Summary

Supersedes #19 by adding non-generic raw byte pipe APIs without renaming or removing the existing generic API surface.

- Adds non-generic `PipeConnection`, `PipeClient`, `PipeServer`, `SingleConnectionPipeClient`, `SingleConnectionPipeServer`, plus matching raw interfaces and event args.
- Reuses the raw pipe transport from generic pipe types so typed pipes remain formatter adapters over the same byte transport.
- Keeps existing generic interfaces source-compatible instead of forcing them to inherit the new raw interfaces.
- Adds access-control overloads for raw servers while preserving existing generic extension usage.
- Preserves zero-length raw byte messages by distinguishing empty payloads from pipe disconnects.
- Adds raw round-trip tests for both multi-connection and single-connection pipe paths.

## Validation

- `dotnet build H.Pipes.sln`
- `dotnet test H.Pipes.sln --no-build`
- `dotnet test H.Pipes.sln --configuration Release`

Known existing warnings remain from formatter trimming/AOT analyzers and `MSTEST0032` in `SerializableTests.cs`; no new build errors.