### PR TITLE
[codex] Wait for raw server connection in test

### DIFF
--- a/src/tests/H.Pipes.Tests/DataTests.cs
+++ b/src/tests/H.Pipes.Tests/DataTests.cs
@@ -209,20 +209,24 @@ public class DataTests
 
         var serverCompletionSource = CreateCompletionSource();
         var clientCompletionSource = CreateCompletionSource();
+        var clientConnectedCompletionSource = new TaskCompletionSource<bool>();
 
         using var registration = cancellationToken.Register(() =>
         {
             serverCompletionSource.TrySetCanceled();
             clientCompletionSource.TrySetCanceled();
+            clientConnectedCompletionSource.TrySetCanceled();
         });
 
         server.MessageReceived += (_, args) => serverCompletionSource.TrySetResult(args.Message);
         client.MessageReceived += (_, args) => clientCompletionSource.TrySetResult(args.Message);
+        server.ClientConnected += (_, _) => clientConnectedCompletionSource.TrySetResult(true);
         server.ExceptionOccurred += (_, args) => serverCompletionSource.TrySetException(args.Exception);
         client.ExceptionOccurred += (_, args) => clientCompletionSource.TrySetException(args.Exception);
 
         await server.StartAsync(cancellationToken).ConfigureAwait(false);
         await client.ConnectAsync(cancellationToken).ConfigureAwait(false);
+        await clientConnectedCompletionSource.Task.ConfigureAwait(false);
 
         foreach (var value in serverToClientValues)
         {


### PR DESCRIPTION
## Summary

- Wait for the raw `PipeServer.ClientConnected` event before sending server-to-client test data.
- Keep the raw round-trip runtime coverage while removing the race where `PipeServer.WriteAsync` could run before the server had added the new connection.

## Why

The `master` push workflow failed on macOS because `NonGenericPipeServerRoundTripsRawBytes` sent from server to client immediately after `PipeClient.ConnectAsync`. The data pipe can be connected from the client side before the server has finished recording and announcing the connection, so the test could write to an empty connected-client set and then wait until timeout.

## Validation

- `dotnet test H.Pipes.sln --configuration Release`